### PR TITLE
fix(packets): observer filter hides multi-observer rows in grouped mode (#1748)

### DIFF
--- a/public/packets.js
+++ b/public/packets.js
@@ -2719,6 +2719,47 @@
     });
   }
 
+  // applyObserverFilter decides which already-loaded packets remain visible
+  // under the current observer filter. Extracted into its own function
+  // (rather than left inline in renderTableRows) specifically so tests can
+  // exercise the real production logic instead of a hand-copied
+  // reimplementation — see #1748 PR review (kent-beck): a test that only
+  // checks a copy of this logic doesn't fail if this function regresses.
+  //
+  // #1748: In grouped mode, the server already filters transmissions
+  // correctly (buildTransmissionWhere emits an EXISTS subquery over ALL
+  // observations of the transmission, not just the displayed one — see
+  // cmd/server/db.go). Each row's `observer_id` here is only the
+  // *representative* observer chosen for display (longest observed path),
+  // which may legitimately differ from the observer that satisfied the
+  // filter. Re-filtering client-side against that single representative —
+  // with `_children` still unpopulated at this point (only fetched lazily
+  // on row-expand or observer-sort-change) — hid every multi-observer
+  // transmission whose representative happened not to be one of the
+  // selected observers. In practice this meant a transmission only stayed
+  // visible when the filtered observer was also the one with the longest
+  // path (which is why the report described it as "works only for
+  // whichever observer logged it first" in dense meshes, where
+  // longest-path and earliest-seen correlate). The server-side EXISTS
+  // filter is authoritative for grouped rows, so no client-side
+  // re-filtering is needed or correct here.
+  //
+  // Flat/expanded mode (groupByHash === false) has no such
+  // representative-vs-actual mismatch — buildPacketWhere filters each
+  // observation row by its own exact observer_id — but we keep the
+  // defensive re-filter for that path since it costs nothing and guards
+  // against any future flat-mode server change.
+  function applyObserverFilter(displayPackets, filters, groupByHash, hashOnly) {
+    if (hashOnly || !filters.observer) return displayPackets;
+    if (groupByHash) return displayPackets;
+    const obsIds = new Set(filters.observer.split(','));
+    return displayPackets.filter(p => {
+      if (obsIds.has(p.observer_id)) return true;
+      if (p._children) return p._children.some(c => obsIds.has(String(c.observer_id)));
+      return false;
+    });
+  }
+
   async function renderTableRows() {
     const tbody = document.getElementById('pktBody');
     if (!tbody) return;
@@ -2761,40 +2802,7 @@
       const types = filters.type.split(',').map(Number);
       displayPackets = displayPackets.filter(p => types.includes(p.payload_type));
     }
-    if (!hashOnly && filters.observer) {
-      // #1748: In grouped mode, the server already filters transmissions
-      // correctly (buildTransmissionWhere emits an EXISTS subquery over ALL
-      // observations of the transmission, not just the displayed one — see
-      // cmd/server/db.go). Each row's `observer_id` here is only the
-      // *representative* observer chosen for display (longest observed
-      // path), which may legitimately differ from the observer that
-      // satisfied the filter. Re-filtering client-side against that single
-      // representative — with `_children` still unpopulated at this point
-      // (only fetched lazily on row-expand or observer-sort-change) — hid
-      // every multi-observer transmission whose representative happened not
-      // to be one of the selected observers. In practice this meant a
-      // transmission only stayed visible when the filtered observer was
-      // also the one with the longest path (which is why the report
-      // described it as "works only for whichever observer logged it
-      // first" in dense meshes, where longest-path and earliest-seen
-      // correlate). The server-side EXISTS filter is authoritative for
-      // grouped rows, so no client-side re-filtering is needed or correct
-      // here.
-      //
-      // Flat/expanded mode (groupByHash === false) has no such
-      // representative-vs-actual mismatch — buildPacketWhere filters each
-      // observation row by its own exact observer_id — but we keep the
-      // defensive re-filter for that path since it costs nothing and
-      // guards against any future flat-mode server change.
-      if (!groupByHash) {
-        const obsIds = new Set(filters.observer.split(','));
-        displayPackets = displayPackets.filter(p => {
-          if (obsIds.has(p.observer_id)) return true;
-          if (p._children) return p._children.some(c => obsIds.has(String(c.observer_id)));
-          return false;
-        });
-      }
-    }
+    displayPackets = applyObserverFilter(displayPackets, filters, groupByHash, hashOnly);
 
     // Packet Filter Language
     const pfCount = document.getElementById('packetFilterCount');
@@ -3905,6 +3913,7 @@
       buildFlatRowHtml,
       _calcVisibleRange,
       buildPacketsParams,
+      applyObserverFilter,
       renderTableRows,
       _setPackets: function(p) { packets = p; },
       _setFilter: function(k, v) { filters[k] = v; },

--- a/public/packets.js
+++ b/public/packets.js
@@ -2762,12 +2762,38 @@
       displayPackets = displayPackets.filter(p => types.includes(p.payload_type));
     }
     if (!hashOnly && filters.observer) {
-      const obsIds = new Set(filters.observer.split(','));
-      displayPackets = displayPackets.filter(p => {
-        if (obsIds.has(p.observer_id)) return true;
-        if (p._children) return p._children.some(c => obsIds.has(String(c.observer_id)));
-        return false;
-      });
+      // #1748: In grouped mode, the server already filters transmissions
+      // correctly (buildTransmissionWhere emits an EXISTS subquery over ALL
+      // observations of the transmission, not just the displayed one — see
+      // cmd/server/db.go). Each row's `observer_id` here is only the
+      // *representative* observer chosen for display (longest observed
+      // path), which may legitimately differ from the observer that
+      // satisfied the filter. Re-filtering client-side against that single
+      // representative — with `_children` still unpopulated at this point
+      // (only fetched lazily on row-expand or observer-sort-change) — hid
+      // every multi-observer transmission whose representative happened not
+      // to be one of the selected observers. In practice this meant a
+      // transmission only stayed visible when the filtered observer was
+      // also the one with the longest path (which is why the report
+      // described it as "works only for whichever observer logged it
+      // first" in dense meshes, where longest-path and earliest-seen
+      // correlate). The server-side EXISTS filter is authoritative for
+      // grouped rows, so no client-side re-filtering is needed or correct
+      // here.
+      //
+      // Flat/expanded mode (groupByHash === false) has no such
+      // representative-vs-actual mismatch — buildPacketWhere filters each
+      // observation row by its own exact observer_id — but we keep the
+      // defensive re-filter for that path since it costs nothing and
+      // guards against any future flat-mode server change.
+      if (!groupByHash) {
+        const obsIds = new Set(filters.observer.split(','));
+        displayPackets = displayPackets.filter(p => {
+          if (obsIds.has(p.observer_id)) return true;
+          if (p._children) return p._children.some(c => obsIds.has(String(c.observer_id)));
+          return false;
+        });
+      }
     }
 
     // Packet Filter Language

--- a/test-frontend-helpers.js
+++ b/test-frontend-helpers.js
@@ -3171,6 +3171,93 @@ console.log('\n=== packets.js: savedTimeWindowMin defaults ===');
   });
 }
 
+// ===== Packets page: observer filter in grouped mode (issue #1748) =====
+{
+  console.log('\n--- Observer filter — grouped vs. flat mode (#1748) ---');
+
+  // Mirrors the client-side observer filter in packets.js renderTableRows()
+  // after the #1748 fix: in grouped mode the server-side EXISTS filter
+  // (buildTransmissionWhere, cmd/server/db.go) is authoritative — every row
+  // it returns was observed by at least one selected observer, even though
+  // each row's `observer_id` is only a *representative* observer (the one
+  // with the longest observed path) that may not itself be in the filter
+  // set. Re-filtering client-side against that single representative is
+  // both redundant and wrong when `_children` (the other observers) hasn't
+  // been fetched yet, which is the default on initial page load.
+  function filterByObserver(packets, obsIdsCsv, groupByHash) {
+    const obsIds = new Set(obsIdsCsv.split(','));
+    if (!groupByHash) {
+      return packets.filter(p => {
+        if (obsIds.has(p.observer_id)) return true;
+        if (p._children) return p._children.some(c => obsIds.has(String(c.observer_id)));
+        return false;
+      });
+    }
+    return packets; // server EXISTS filter already guarantees correctness
+  }
+
+  // A transmission the server correctly returned for observer "B" (it was
+  // one of several observers of this hash) but whose displayed
+  // "representative" observer is "A" (longest path) — exactly the shape
+  // QueryGroupedPackets returns. `_children` is undefined, matching the
+  // state on initial load (only fetched lazily on expand/obs-sort-change).
+  const groupedRowRepresentativeNotFiltered = {
+    hash: 'hash1', observer_id: 'A', observer_count: 3, _children: undefined,
+  };
+  // A single-observer transmission whose only observer is NOT in the filter —
+  // must still be excluded (it genuinely wasn't observed by the filtered
+  // observer; the server wouldn't have returned it in the first place, but
+  // the client function must not accidentally let everything through).
+  const groupedRowGenuinelyExcludedByServer = {
+    hash: 'hash2', observer_id: 'C', observer_count: 1, _children: undefined,
+  };
+  // A flat/expanded-mode row: single observation, own observer_id.
+  const flatRowMatching = { hash: 'hash3', observer_id: 'B' };
+  const flatRowNonMatching = { hash: 'hash4', observer_id: 'A' };
+  // A flat/expanded-mode row with already-loaded children, only one of
+  // which matches — the pre-existing children-aware fallback path.
+  const flatRowWithMatchingChild = {
+    hash: 'hash5', observer_id: 'A',
+    _children: [{ observer_id: 'A' }, { observer_id: 'B' }],
+  };
+
+  test('grouped mode: keeps a multi-observer row whose representative is not the filtered observer (#1748 core bug)', () => {
+    const result = filterByObserver([groupedRowRepresentativeNotFiltered], 'B', true);
+    assert.strictEqual(result.length, 1, 'server already guaranteed observer B saw this transmission');
+  });
+
+  test('grouped mode: does not need _children to keep a valid server-filtered row', () => {
+    // The defining regression: _children is undefined (not yet fetched),
+    // and observer_id (the representative) does not match — pre-fix this
+    // returned zero rows.
+    const result = filterByObserver([groupedRowRepresentativeNotFiltered], 'B', true);
+    assert.strictEqual(result.length, 1);
+  });
+
+  test('grouped mode: passes through rows unfiltered (server EXISTS filter is authoritative)', () => {
+    // The client no longer second-guesses the server in grouped mode at all —
+    // this row would never have been returned by the server if observer C
+    // weren't a match, so the client trusts it.
+    const result = filterByObserver([groupedRowGenuinelyExcludedByServer], 'B', true);
+    assert.strictEqual(result.length, 1, 'grouped mode does not re-filter; server already applied the correct filter');
+  });
+
+  test('flat mode: keeps a row whose own observer_id matches', () => {
+    const result = filterByObserver([flatRowMatching], 'B', false);
+    assert.strictEqual(result.length, 1);
+  });
+
+  test('flat mode: excludes a row whose own observer_id does not match and has no children', () => {
+    const result = filterByObserver([flatRowNonMatching], 'B', false);
+    assert.strictEqual(result.length, 0);
+  });
+
+  test('flat mode: falls back to matching children when representative does not match', () => {
+    const result = filterByObserver([flatRowWithMatchingChild], 'B', false);
+    assert.strictEqual(result.length, 1, 'observer B is among the already-loaded children');
+  });
+}
+
 // ===== Packets page: virtual scroll infrastructure =====
 {
   console.log('\nPackets page — virtual scroll:');

--- a/test-frontend-helpers.js
+++ b/test-frontend-helpers.js
@@ -3175,26 +3175,20 @@ console.log('\n=== packets.js: savedTimeWindowMin defaults ===');
 {
   console.log('\n--- Observer filter — grouped vs. flat mode (#1748) ---');
 
-  // Mirrors the client-side observer filter in packets.js renderTableRows()
-  // after the #1748 fix: in grouped mode the server-side EXISTS filter
-  // (buildTransmissionWhere, cmd/server/db.go) is authoritative — every row
-  // it returns was observed by at least one selected observer, even though
-  // each row's `observer_id` is only a *representative* observer (the one
-  // with the longest observed path) that may not itself be in the filter
-  // set. Re-filtering client-side against that single representative is
-  // both redundant and wrong when `_children` (the other observers) hasn't
-  // been fetched yet, which is the default on initial page load.
-  function filterByObserver(packets, obsIdsCsv, groupByHash) {
-    const obsIds = new Set(obsIdsCsv.split(','));
-    if (!groupByHash) {
-      return packets.filter(p => {
-        if (obsIds.has(p.observer_id)) return true;
-        if (p._children) return p._children.some(c => obsIds.has(String(c.observer_id)));
-        return false;
-      });
-    }
-    return packets; // server EXISTS filter already guarantees correctness
-  }
+  // Load the REAL applyObserverFilter from packets.js via sandbox, rather
+  // than testing a hand-copied reimplementation of its logic. Per #1748 PR
+  // review (kent-beck): a test that only checks a copy doesn't fail if the
+  // actual production function regresses. Mirrors the same loadInCtx
+  // pattern used below for _calcVisibleRange.
+  const obsFilterCtx = makeSandbox();
+  obsFilterCtx.registerPage = (name, handlers) => {};
+  obsFilterCtx.onWS = () => {};
+  obsFilterCtx.offWS = () => {};
+  obsFilterCtx.api = () => Promise.resolve({});
+  obsFilterCtx.window.getParsedPath = () => [];
+  obsFilterCtx.window.getParsedDecoded = () => ({});
+  loadInCtx(obsFilterCtx, 'public/packets.js');
+  const applyObserverFilter = obsFilterCtx.window._packetsTestAPI.applyObserverFilter;
 
   // A transmission the server correctly returned for observer "B" (it was
   // one of several observers of this hash) but whose displayed
@@ -3222,7 +3216,7 @@ console.log('\n=== packets.js: savedTimeWindowMin defaults ===');
   };
 
   test('grouped mode: keeps a multi-observer row whose representative is not the filtered observer (#1748 core bug)', () => {
-    const result = filterByObserver([groupedRowRepresentativeNotFiltered], 'B', true);
+    const result = applyObserverFilter([groupedRowRepresentativeNotFiltered], { observer: 'B' }, true, false);
     assert.strictEqual(result.length, 1, 'server already guaranteed observer B saw this transmission');
   });
 
@@ -3230,7 +3224,7 @@ console.log('\n=== packets.js: savedTimeWindowMin defaults ===');
     // The defining regression: _children is undefined (not yet fetched),
     // and observer_id (the representative) does not match — pre-fix this
     // returned zero rows.
-    const result = filterByObserver([groupedRowRepresentativeNotFiltered], 'B', true);
+    const result = applyObserverFilter([groupedRowRepresentativeNotFiltered], { observer: 'B' }, true, false);
     assert.strictEqual(result.length, 1);
   });
 
@@ -3238,23 +3232,33 @@ console.log('\n=== packets.js: savedTimeWindowMin defaults ===');
     // The client no longer second-guesses the server in grouped mode at all —
     // this row would never have been returned by the server if observer C
     // weren't a match, so the client trusts it.
-    const result = filterByObserver([groupedRowGenuinelyExcludedByServer], 'B', true);
+    const result = applyObserverFilter([groupedRowGenuinelyExcludedByServer], { observer: 'B' }, true, false);
     assert.strictEqual(result.length, 1, 'grouped mode does not re-filter; server already applied the correct filter');
   });
 
   test('flat mode: keeps a row whose own observer_id matches', () => {
-    const result = filterByObserver([flatRowMatching], 'B', false);
+    const result = applyObserverFilter([flatRowMatching], { observer: 'B' }, false, false);
     assert.strictEqual(result.length, 1);
   });
 
   test('flat mode: excludes a row whose own observer_id does not match and has no children', () => {
-    const result = filterByObserver([flatRowNonMatching], 'B', false);
+    const result = applyObserverFilter([flatRowNonMatching], { observer: 'B' }, false, false);
     assert.strictEqual(result.length, 0);
   });
 
   test('flat mode: falls back to matching children when representative does not match', () => {
-    const result = filterByObserver([flatRowWithMatchingChild], 'B', false);
+    const result = applyObserverFilter([flatRowWithMatchingChild], { observer: 'B' }, false, false);
     assert.strictEqual(result.length, 1, 'observer B is among the already-loaded children');
+  });
+
+  test('hashOnly bypasses the observer filter entirely (pinned-hash view)', () => {
+    const result = applyObserverFilter([groupedRowGenuinelyExcludedByServer, flatRowNonMatching], { observer: 'B' }, true, true);
+    assert.strictEqual(result.length, 2, 'hashOnly must return every row unfiltered, matching renderTableRows()');
+  });
+
+  test('no observer filter set: all rows pass through unchanged', () => {
+    const result = applyObserverFilter([groupedRowGenuinelyExcludedByServer, flatRowNonMatching], {}, false, false);
+    assert.strictEqual(result.length, 2);
   });
 }
 


### PR DESCRIPTION
Closes #1748.

## Root cause

`renderTableRows()` in `public/packets.js` re-filtered the already server-filtered `/api/packets` (grouped) results client-side, comparing `filters.observer` against each row's `observer_id`. But that field is only the **representative** observer chosen for display — `QueryGroupedPackets` (`cmd/server/db.go:554-606`) picks the observation with the longest observed path via a `LEFT JOIN ... ORDER BY length(path_json) DESC LIMIT 1`, purely for display purposes.

The server-side filter (`buildTransmissionWhere`, `cmd/server/db.go:725-790`) is already correct: it uses an `EXISTS` subquery over **all** observations of a transmission, so any row it returns was genuinely seen by at least one selected observer.

The client then discarded rows *again*, checking only the representative's `observer_id`, with a fallback to `p._children` — which is `undefined` on initial page load (only fetched lazily on row-expand or when the observer-sort dropdown changes, see the `obsSortSel` change handler). Net effect: a multi-observer transmission stayed visible under an observer filter only when the filtered observer happened to also be the representative (longest-path) observer — which matches the reported "works only for whichever observer logged it first" behavior in dense meshes, where longest-path and earliest-seen correlate.

## Fix

Skip the client-side observer re-filter entirely when `groupByHash` is active — the server's `EXISTS` filter is authoritative for grouped rows and needs no client-side correction. The flat/expanded-mode path (single-observation rows, each with its own exact `observer_id` from `buildPacketWhere`) keeps the existing children-aware filter unchanged, which already had test coverage under #537 for the case where `_children` is already populated.

## Tests

Added 6 cases in `test-frontend-helpers.js` covering the specific gap #537's tests didn't reach — grouped mode with `_children` still `undefined` (the actual initial-load state that triggers this bug). New tests confirm:
- A multi-observer row whose representative doesn't match the filter is kept in grouped mode (the core bug).
- Grouped mode never re-filters client-side (trusts the server).
- Flat mode behavior is unchanged (matches by own `observer_id`, falls back to already-loaded `_children`).

Full run: `test-frontend-helpers.js` 631 passed / 2 failed (same 2 pre-existing `favStar` failures reproduce identically on unmodified `master` — unrelated). `test-packet-filter.js` 92/92. `test-aging.js` 18/18.

Operator context: running CoreScope for SaarMesh (SaarLorLux, DE/FR/LU, 800+ nodes, 14 observers) — this was hiding a large share of traffic whenever filtering by a non-primary observer in our dense mesh.

Co-Authored-By: Claude <noreply@anthropic.com>