### PR TITLE
feat(#1784): wire consumers to pathTrust.minHashBytesForMapping config

### DIFF
--- a/cmd/ingestor/config.go
+++ b/cmd/ingestor/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/meshcore-analyzer/dbconfig"
 	"github.com/meshcore-analyzer/geofilter"
+	"github.com/meshcore-analyzer/packetpath"
 )
 
 // MQTTSource represents a single MQTT broker connection.
@@ -56,6 +57,7 @@ type Config struct {
 	Runtime            *RuntimeConfig          `json:"runtime,omitempty"`
 	ClientRxCoverage   *ClientRxCoverageConfig `json:"clientRxCoverage,omitempty"`
 	GeoFilter          *GeoFilterConfig        `json:"geo_filter,omitempty"`
+	PathTrust          *PathTrustConfig        `json:"pathTrust,omitempty"`
 	ForeignAdverts     *ForeignAdvertConfig    `json:"foreignAdverts,omitempty"`
 	ValidateSignatures *bool                   `json:"validateSignatures,omitempty"`
 	DB                 *DBConfig               `json:"db,omitempty"`
@@ -111,6 +113,10 @@ func (c *Config) IngestBufferSizeOrDefault() int {
 
 // GeoFilterConfig is an alias for the shared geofilter.Config type.
 type GeoFilterConfig = geofilter.Config
+
+// PathTrustConfig is an alias for the shared packetpath.TrustConfig type
+// (issue #1784). See packetpath.TrustConfig for the full doc comment.
+type PathTrustConfig = packetpath.TrustConfig
 
 // ForeignAdvertConfig controls how the ingestor handles ADVERTs whose GPS lies
 // outside the configured geofilter polygon (#730). Modes:
@@ -236,6 +242,15 @@ func (c *Config) ObserverDaysOrDefault() int {
 		return c.Retention.ObserverDays
 	}
 	return 14
+}
+
+// GetPathTrust returns the effective path-trust config, applying
+// DefaultMinHashBytesForMapping when unset (issue #1784).
+func (c *Config) GetPathTrust() PathTrustConfig {
+	if c != nil && c.PathTrust != nil {
+		return *c.PathTrust
+	}
+	return PathTrustConfig{MinHashBytesForMapping: packetpath.DefaultMinHashBytesForMapping}
 }
 
 // IsObserverBlacklisted returns true if the given observer ID is in the observerBlacklist.

--- a/cmd/ingestor/config.go
+++ b/cmd/ingestor/config.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/meshcore-analyzer/dbconfig"
 	"github.com/meshcore-analyzer/geofilter"
-	"github.com/meshcore-analyzer/packetpath"
 )
 
 // MQTTSource represents a single MQTT broker connection.
@@ -57,7 +56,6 @@ type Config struct {
 	Runtime            *RuntimeConfig          `json:"runtime,omitempty"`
 	ClientRxCoverage   *ClientRxCoverageConfig `json:"clientRxCoverage,omitempty"`
 	GeoFilter          *GeoFilterConfig        `json:"geo_filter,omitempty"`
-	PathTrust          *PathTrustConfig        `json:"pathTrust,omitempty"`
 	ForeignAdverts     *ForeignAdvertConfig    `json:"foreignAdverts,omitempty"`
 	ValidateSignatures *bool                   `json:"validateSignatures,omitempty"`
 	DB                 *DBConfig               `json:"db,omitempty"`
@@ -113,10 +111,6 @@ func (c *Config) IngestBufferSizeOrDefault() int {
 
 // GeoFilterConfig is an alias for the shared geofilter.Config type.
 type GeoFilterConfig = geofilter.Config
-
-// PathTrustConfig is an alias for the shared packetpath.TrustConfig type
-// (issue #1784). See packetpath.TrustConfig for the full doc comment.
-type PathTrustConfig = packetpath.TrustConfig
 
 // ForeignAdvertConfig controls how the ingestor handles ADVERTs whose GPS lies
 // outside the configured geofilter polygon (#730). Modes:
@@ -242,15 +236,6 @@ func (c *Config) ObserverDaysOrDefault() int {
 		return c.Retention.ObserverDays
 	}
 	return 14
-}
-
-// GetPathTrust returns the effective path-trust config, applying
-// DefaultMinHashBytesForMapping when unset (issue #1784).
-func (c *Config) GetPathTrust() PathTrustConfig {
-	if c != nil && c.PathTrust != nil {
-		return *c.PathTrust
-	}
-	return PathTrustConfig{MinHashBytesForMapping: packetpath.DefaultMinHashBytesForMapping}
 }
 
 // IsObserverBlacklisted returns true if the given observer ID is in the observerBlacklist.

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/meshcore-analyzer/dbconfig"
 	"github.com/meshcore-analyzer/geofilter"
+	"github.com/meshcore-analyzer/packetpath"
 )
 
 // AreaEntry defines a geographic area by polygon or bounding box.
@@ -105,6 +106,7 @@ type Config struct {
 
 	Roles            map[string]interface{} `json:"roles"`
 	HealthThresholds *HealthThresholds      `json:"healthThresholds"`
+	PathTrust        *PathTrustConfig       `json:"pathTrust,omitempty"`
 	Map              map[string]interface{} `json:"map"`
 	Tiles            map[string]interface{} `json:"tiles"` // deprecated
 	SnrThresholds    map[string]interface{} `json:"snrThresholds"`
@@ -308,6 +310,10 @@ type PacketStoreConfig struct {
 
 // GeoFilterConfig is an alias for the shared geofilter.Config type.
 type GeoFilterConfig = geofilter.Config
+
+// PathTrustConfig is an alias for the shared packetpath.TrustConfig type
+// (issue #1784). See packetpath.TrustConfig for the full doc comment.
+type PathTrustConfig = packetpath.TrustConfig
 
 // RuntimeConfig holds Go runtime tuning knobs (#1010).
 type RuntimeConfig struct {
@@ -583,6 +589,15 @@ func (c *Config) GetHealthThresholds() HealthThresholds {
 		h.ObserverStaleMinutes = 1440
 	}
 	return h
+}
+
+// GetPathTrust returns the effective path-trust config, applying
+// DefaultMinHashBytesForMapping when unset (issue #1784).
+func (c *Config) GetPathTrust() PathTrustConfig {
+	if c != nil && c.PathTrust != nil {
+		return *c.PathTrust
+	}
+	return PathTrustConfig{MinHashBytesForMapping: packetpath.DefaultMinHashBytesForMapping}
 }
 
 // GetHealthMs returns degraded/silent thresholds in ms for a given role.

--- a/cmd/server/neighbor_api.go
+++ b/cmd/server/neighbor_api.go
@@ -91,6 +91,7 @@ func (s *Server) getNeighborGraph() *NeighborGraph {
 			if s.cfg != nil {
 				opts.EnableLog = s.cfg.DebugAffinity
 				opts.MaxEdgeKm = s.cfg.NeighborMaxEdgeKm()
+				opts.PathTrust = s.cfg.PathTrust
 			}
 			s.neighborGraph = BuildFromStoreWithOptions(s.store, opts)
 		} else {

--- a/cmd/server/neighbor_graph.go
+++ b/cmd/server/neighbor_graph.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/meshcore-analyzer/packetpath"
 )
 
 // ─── Constants ─────────────────────────────────────────────────────────────────
@@ -234,6 +236,12 @@ func BuildFromStore(store *PacketStore) *NeighborGraph {
 type BuildOptions struct {
 	EnableLog bool    // structured disambiguation logging
 	MaxEdgeKm float64 // geo-sanity threshold; 0 disables the filter
+	// PathTrust is the trust threshold config for path-hash observations
+	// (issue #1784). When nil, the default threshold (1 byte) is used:
+	// all prefix lengths count as evidence (backward-compatible). Set
+	// MinHashBytesForMapping: 2 to exclude 1-byte observations from
+	// neighbor-edge building, or 3 for the strictest mode.
+	PathTrust *packetpath.TrustConfig
 }
 
 // DefaultMaxEdgeKm is the conservative built-in cap for the
@@ -319,16 +327,20 @@ func BuildFromStoreWithOptions(store *PacketStore, opts BuildOptions) *NeighborG
 			if isAdvert && fromLower != "" {
 				firstHop := cachedToLower(lowerCache, path[0])
 				if fromLower != firstHop { // self-edge guard (shouldn't happen but spec says check)
-					candidates := pm.m[firstHop]
-					g.upsertEdgeWithCandidates(fromLower, firstHop, candidates, observerPK, obs.SNR, parseTimestamp(obs.Timestamp), lowerCache)
+					if packetpath.MeetsPathTrust(len(path[0])/2, opts.PathTrust) {
+						candidates := pm.m[firstHop]
+						g.upsertEdgeWithCandidates(fromLower, firstHop, candidates, observerPK, obs.SNR, parseTimestamp(obs.Timestamp), lowerCache)
+					}
 				}
 			}
 
 			// Edge 2: observer ↔ path[last] — ALL packet types
 			lastHop := cachedToLower(lowerCache, path[len(path)-1])
 			if observerPK != lastHop { // self-edge guard
-				candidates := pm.m[lastHop]
-				g.upsertEdgeWithCandidates(observerPK, lastHop, candidates, observerPK, obs.SNR, parseTimestamp(obs.Timestamp), lowerCache)
+				if packetpath.MeetsPathTrust(len(path[len(path)-1])/2, opts.PathTrust) {
+					candidates := pm.m[lastHop]
+					g.upsertEdgeWithCandidates(observerPK, lastHop, candidates, observerPK, obs.SNR, parseTimestamp(obs.Timestamp), lowerCache)
+				}
 			}
 		}
 	}

--- a/cmd/server/neighbor_graph.go
+++ b/cmd/server/neighbor_graph.go
@@ -237,10 +237,10 @@ type BuildOptions struct {
 	EnableLog bool    // structured disambiguation logging
 	MaxEdgeKm float64 // geo-sanity threshold; 0 disables the filter
 	// PathTrust is the trust threshold config for path-hash observations
-	// (issue #1784). When nil, the default threshold (1 byte) is used:
-	// all prefix lengths count as evidence (backward-compatible). Set
-	// MinHashBytesForMapping: 2 to exclude 1-byte observations from
-	// neighbor-edge building, or 3 for the strictest mode.
+	// (issue #1784). When nil, the default threshold (2 bytes) is used:
+	// 1-byte observations do not count as mapping evidence. Set
+	// MinHashBytesForMapping: 1 to opt into legacy trust-all behavior,
+	// or 3 for the strictest mode.
 	PathTrust *packetpath.TrustConfig
 }
 

--- a/cmd/server/neighbor_graph_test.go
+++ b/cmd/server/neighbor_graph_test.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"testing"
 	"time"
+
+	"github.com/meshcore-analyzer/packetpath"
 )
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
@@ -837,6 +839,46 @@ func BenchmarkBuildFromStore(b *testing.B) {
 
 // TestBuildNeighborGraph_CountsByMode (issue #1638): verify per-hash-mode
 // edge counts are tracked separately from the flat Count, so the frontend
+// TestBuildNeighborGraph_PathTrustExcludes1ByteHops verifies that
+// BuildFromStoreWithOptions respects the PathTrust threshold. When
+// MinHashBytesForMapping=2, 1-byte prefix observations are excluded
+// from neighbor-edge building. At threshold=1 (trust-all) they are
+// included — backward-compatible. Kent Beck review: consumer wiring must
+// be tested, not just the pure helper.
+func TestBuildNeighborGraph_PathTrustExcludes1ByteHops(t *testing.T) {
+	nodes := []nodeInfo{
+		{Role: "repeater", PublicKey: "ccc0000100000000000000000000000000000000000000000000000000000001", Name: "NodeC-1"},
+		{Role: "repeater", PublicKey: "ccc0000200000000000000000000000000000000000000000000000000000002", Name: "NodeC-2"},
+		{Role: "repeater", PublicKey: "aaa0000100000000000000000000000000000000000000000000000000000003", Name: "Originator"},
+		{Role: "repeater", PublicKey: "obs00001000000000000000000000000000000000000000000000000000000004", Name: "Observer"},
+	}
+	// ADVERT with 1-byte path hop "cc" (hex length 2 = 1 byte).
+	tx := ngMakeTx(1, 4, ngPubKeyJSON("aaa0000100000000000000000000000000000000000000000000000000000003"), []*StoreObs{
+		ngMakeObs("obs00001000000000000000000000000000000000000000000000000000000004", `["cc"]`, nowStr, ngFloatPtr(-12)),
+	})
+	store := ngTestStore(nodes, []*StoreTx{tx})
+
+	// Threshold=2: 1-byte "cc" prefix excluded → no edges.
+	g := BuildFromStoreWithOptions(store, BuildOptions{
+		PathTrust: &packetpath.TrustConfig{MinHashBytesForMapping: 2},
+		MaxEdgeKm: DefaultMaxEdgeKm,
+	})
+	if edges := g.AllEdges(); len(edges) > 0 {
+		for _, e := range edges {
+			t.Errorf("expected no edges with pathTrust=2 + 1-byte prefix, got prefix=%q", e.Prefix)
+		}
+	}
+
+	// Threshold=1: 1-byte prefix included (trust-all, backward-compatible).
+	g1 := BuildFromStoreWithOptions(store, BuildOptions{
+		PathTrust: &packetpath.TrustConfig{MinHashBytesForMapping: 1},
+		MaxEdgeKm: DefaultMaxEdgeKm,
+	})
+	if edges1 := g1.AllEdges(); len(edges1) == 0 {
+		t.Fatal("expected edges with pathTrust=1 (trust-all), got 0")
+	}
+}
+
 // confidence indicator can weight 3-byte (effectively unambiguous) sightings
 // higher than 1-byte (high-collision) sightings. Modes track firmware-valid
 // hash sizes 1/2/3 per Packet.cpp:13-18.

--- a/cmd/server/neighbor_graph_test.go
+++ b/cmd/server/neighbor_graph_test.go
@@ -837,8 +837,6 @@ func BenchmarkBuildFromStore(b *testing.B) {
 	}
 }
 
-// TestBuildNeighborGraph_CountsByMode (issue #1638): verify per-hash-mode
-// edge counts are tracked separately from the flat Count, so the frontend
 // TestBuildNeighborGraph_PathTrustExcludes1ByteHops verifies that
 // BuildFromStoreWithOptions respects the PathTrust threshold. When
 // MinHashBytesForMapping=2, 1-byte prefix observations are excluded

--- a/cmd/server/neighbor_graph_test.go
+++ b/cmd/server/neighbor_graph_test.go
@@ -43,7 +43,7 @@ func ngTestStore(nodes []nodeInfo, packets []*StoreTx) *PacketStore {
 	return ps
 }
 
-func ngIntPtr(v int) *int         { return &v }
+func ngIntPtr(v int) *int           { return &v }
 func ngFloatPtr(v float64) *float64 { return &v }
 
 func ngMakeTx(id int, payloadType int, decodedJSON string, obs []*StoreObs) *StoreTx {
@@ -641,7 +641,10 @@ func TestBuildNeighborGraph_AdvertPubKeyField(t *testing.T) {
 		ngMakeObs("obs0000100112233445566778899001122334455667788990011223344556677", `["r1"]`, nowStr, ngFloatPtr(-8.5)),
 	})
 	store := ngTestStore(nodes, []*StoreTx{tx})
-	g := BuildFromStore(store)
+	g := BuildFromStoreWithOptions(store, BuildOptions{
+		PathTrust: &packetpath.TrustConfig{MinHashBytesForMapping: 1},
+		MaxEdgeKm: DefaultMaxEdgeKm,
+	})
 
 	edges := g.AllEdges()
 	if len(edges) < 1 {
@@ -678,7 +681,10 @@ func TestBuildNeighborGraph_OneByteHashPrefixes(t *testing.T) {
 		ngMakeObs("obs1234500000000000000000000000000000000000000000000000000000004", `["c0"]`, nowStr, ngFloatPtr(-12)),
 	})
 	store := ngTestStore(nodes, []*StoreTx{tx})
-	g := BuildFromStore(store)
+	g := BuildFromStoreWithOptions(store, BuildOptions{
+		PathTrust: &packetpath.TrustConfig{MinHashBytesForMapping: 1},
+		MaxEdgeKm: DefaultMaxEdgeKm,
+	})
 
 	edges := g.AllEdges()
 	if len(edges) == 0 {
@@ -920,7 +926,10 @@ func TestBuildNeighborGraph_CountsByMode(t *testing.T) {
 		}),
 	}
 	store := ngTestStore(nodes, txs)
-	g := BuildFromStore(store)
+	g := BuildFromStoreWithOptions(store, BuildOptions{
+		PathTrust: &packetpath.TrustConfig{MinHashBytesForMapping: 1},
+		MaxEdgeKm: DefaultMaxEdgeKm,
+	})
 
 	edges := g.Neighbors("aaaa1111")
 	var xr1 *NeighborEdge

--- a/cmd/server/neighbor_graph_test.go
+++ b/cmd/server/neighbor_graph_test.go
@@ -877,6 +877,26 @@ func TestBuildNeighborGraph_PathTrustExcludes1ByteHops(t *testing.T) {
 	}
 }
 
+// TestBuildNeighborGraph_PathTrustDefaultExcludes1ByteHops pins the configured
+// default for installations without a pathTrust block. The default is strict:
+// one-byte prefixes are not trusted as mapping evidence.
+func TestBuildNeighborGraph_PathTrustDefaultExcludes1ByteHops(t *testing.T) {
+	nodes := []nodeInfo{
+		{Role: "repeater", PublicKey: "ccc0000100000000000000000000000000000000000000000000000000000001", Name: "NodeC-1"},
+		{Role: "repeater", PublicKey: "ccc0000200000000000000000000000000000000000000000000000000000002", Name: "NodeC-2"},
+		{Role: "repeater", PublicKey: "aaa0000100000000000000000000000000000000000000000000000000000003", Name: "Originator"},
+		{Role: "repeater", PublicKey: "obs00001000000000000000000000000000000000000000000000000000000004", Name: "Observer"},
+	}
+	tx := ngMakeTx(1, 4, ngPubKeyJSON("aaa0000100000000000000000000000000000000000000000000000000000003"), []*StoreObs{
+		ngMakeObs("obs00001000000000000000000000000000000000000000000000000000000004", `["cc"]`, nowStr, ngFloatPtr(-12)),
+	})
+
+	g := BuildFromStoreWithOptions(ngTestStore(nodes, []*StoreTx{tx}), BuildOptions{MaxEdgeKm: DefaultMaxEdgeKm})
+	if edges := g.AllEdges(); len(edges) != 0 {
+		t.Fatalf("expected default path trust to exclude 1-byte prefix, got %d edges", len(edges))
+	}
+}
+
 // confidence indicator can weight 3-byte (effectively unambiguous) sightings
 // higher than 1-byte (high-collision) sightings. Modes track firmware-valid
 // hash sizes 1/2/3 per Packet.cpp:13-18.

--- a/cmd/server/path_inspect.go
+++ b/cmd/server/path_inspect.go
@@ -220,12 +220,12 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 		evidence := make([]hopEvidence, len(entry.evidence))
 		copy(evidence, entry.evidence)
 		allHopsTrusted := true
+		pt := s.cfg.GetPathTrust()
 		for hi, ev := range evidence {
 			if hi >= len(req.Prefixes) {
 				break
 			}
 			prefix := req.Prefixes[hi]
-				pt := s.cfg.GetPathTrust()
 			trusted := packetpath.MeetsPathTrust(len(prefix)/2, &pt)
 			if !trusted {
 				allHopsTrusted = false

--- a/cmd/server/path_inspect.go
+++ b/cmd/server/path_inspect.go
@@ -225,7 +225,8 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 			prefix := req.Prefixes[hi]
-			trusted := packetpath.MeetsPathTrust(len(prefix)/2, s.cfg.PathTrust)
+				pt := s.cfg.GetPathTrust()
+			trusted := packetpath.MeetsPathTrust(len(prefix)/2, &pt)
 			if !trusted {
 				allHopsTrusted = false
 			}
@@ -266,6 +267,7 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	elapsed := time.Since(start).Milliseconds()
+	statsMinBytes := s.cfg.GetPathTrust()
 	resp := pathInspectResponse{
 		Candidates: candidates,
 		Stale:      stale,
@@ -277,7 +279,7 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 			"beamWidth":              beamWidth,
 			"expansionsRun":          len(req.Prefixes) * beamWidth,
 			"elapsedMs":              elapsed,
-			"minHashBytesForMapping": s.cfg.GetPathTrust().MinHashBytesOrDefault(),
+			"minHashBytesForMapping": statsMinBytes.MinHashBytesOrDefault(),
 		},
 	}
 

--- a/cmd/server/path_inspect.go
+++ b/cmd/server/path_inspect.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/meshcore-analyzer/packetpath"
 )
 
 // ─── Path Inspector ────────────────────────────────────────────────────────────
@@ -45,6 +47,7 @@ type hopEvidence struct {
 	CandidatesConsidered int              `json:"candidatesConsidered"`
 	Chosen               string           `json:"chosen"`
 	EdgeWeight           float64          `json:"edgeWeight"`
+	Trusted              bool             `json:"trusted"`
 	Alternatives         []hopAlternative `json:"alternatives,omitempty"`
 }
 
@@ -216,18 +219,22 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 		// Populate per-hop alternatives: other candidates at each hop that weren't chosen.
 		evidence := make([]hopEvidence, len(entry.evidence))
 		copy(evidence, entry.evidence)
+		allHopsTrusted := true
 		for hi, ev := range evidence {
 			if hi >= len(req.Prefixes) {
 				break
 			}
 			prefix := req.Prefixes[hi]
+			trusted := packetpath.MeetsPathTrust(len(prefix)/2, s.cfg.PathTrust)
+			if !trusted {
+				allHopsTrusted = false
+			}
 			allCands := pm.m[prefix]
 			var alts []hopAlternative
 			for _, c := range allCands {
 				if !canAppearInPath(c.Role) || c.PublicKey == ev.Chosen {
 					continue
 				}
-				// Score this alternative in context of the partial path up to this hop.
 				var partialEntry beamEntry
 				if hi > 0 {
 					partialEntry = beamEntry{pubkeys: entry.pubkeys[:hi], names: entry.names[:hi], score: 1.0}
@@ -235,7 +242,6 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 				altScore := s.store.scoreHop(partialEntry, c, ev.CandidatesConsidered, graph, nodeByPK, now, hi)
 				alts = append(alts, hopAlternative{PublicKey: c.PublicKey, Name: c.Name, Score: math.Round(altScore*1000) / 1000})
 			}
-			// Sort alts by score desc, cap at 5.
 			sort.Slice(alts, func(i, j int) bool { return alts[i].Score > alts[j].Score })
 			if len(alts) > 5 {
 				alts = alts[:5]
@@ -245,6 +251,7 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 				CandidatesConsidered: ev.CandidatesConsidered,
 				Chosen:               ev.Chosen,
 				EdgeWeight:           ev.EdgeWeight,
+				Trusted:              trusted,
 				Alternatives:         alts,
 			}
 		}
@@ -253,7 +260,7 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 			Path:        entry.pubkeys,
 			Names:       entry.names,
 			Score:       math.Round(score*1000) / 1000,
-			Speculative: score < speculativeThreshold,
+			Speculative: score < speculativeThreshold || !allHopsTrusted,
 			Evidence:    pathEvidence{PerHop: evidence},
 		})
 	}
@@ -267,9 +274,10 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 			"hops":     len(req.Prefixes),
 		},
 		Stats: map[string]interface{}{
-			"beamWidth":     beamWidth,
-			"expansionsRun": len(req.Prefixes) * beamWidth,
-			"elapsedMs":     elapsed,
+			"beamWidth":              beamWidth,
+			"expansionsRun":          len(req.Prefixes) * beamWidth,
+			"elapsedMs":              elapsed,
+			"minHashBytesForMapping": s.cfg.GetPathTrust().MinHashBytesOrDefault(),
 		},
 	}
 

--- a/cmd/server/path_inspect.go
+++ b/cmd/server/path_inspect.go
@@ -200,6 +200,7 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 
 	// Beam search.
 	beam := s.store.beamSearch(req.Prefixes, pm, graph, nodeByPK, now)
+	pt := s.cfg.GetPathTrust()
 
 	// Sort by score descending, take top limit.
 	sortBeam(beam)
@@ -220,7 +221,6 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 		evidence := make([]hopEvidence, len(entry.evidence))
 		copy(evidence, entry.evidence)
 		allHopsTrusted := true
-		pt := s.cfg.GetPathTrust()
 		for hi, ev := range evidence {
 			if hi >= len(req.Prefixes) {
 				break
@@ -267,7 +267,6 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	elapsed := time.Since(start).Milliseconds()
-	statsMinBytes := s.cfg.GetPathTrust()
 	resp := pathInspectResponse{
 		Candidates: candidates,
 		Stale:      stale,
@@ -279,7 +278,7 @@ func (s *Server) handlePathInspect(w http.ResponseWriter, r *http.Request) {
 			"beamWidth":              beamWidth,
 			"expansionsRun":          len(req.Prefixes) * beamWidth,
 			"elapsedMs":              elapsed,
-			"minHashBytesForMapping": statsMinBytes.MinHashBytesOrDefault(),
+			"minHashBytesForMapping": pt.MinHashBytesOrDefault(),
 		},
 	}
 

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -457,7 +457,7 @@ func (s *Server) handleConfigClient(w http.ResponseWriter, r *http.Request) {
 		Tiles:               s.cfg.Tiles,
 		Customizer:          CustomizerClientConfig{DisabledTabs: disabledTabs},
 		ClientRxCoverage:    s.cfg.ClientRxCoverageEnabled(),
-		PathTrust:           s.cfg.PathTrust,
+		PathTrust:           func() *PathTrustConfig { pt := s.cfg.GetPathTrust(); return &pt }(),
 	})
 }
 

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -457,6 +457,7 @@ func (s *Server) handleConfigClient(w http.ResponseWriter, r *http.Request) {
 		Tiles:               s.cfg.Tiles,
 		Customizer:          CustomizerClientConfig{DisabledTabs: disabledTabs},
 		ClientRxCoverage:    s.cfg.ClientRxCoverageEnabled(),
+		PathTrust:           s.cfg.PathTrust,
 	})
 }
 

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -437,6 +437,7 @@ func (s *Server) handleConfigClient(w http.ResponseWriter, r *http.Request) {
 	if s.cfg.Customizer != nil && s.cfg.Customizer.DisabledTabs != nil {
 		disabledTabs = s.cfg.Customizer.DisabledTabs
 	}
+	pathTrust := s.cfg.GetPathTrust()
 	writeJSON(w, ClientConfigResponse{
 		Roles:               s.cfg.Roles,
 		HealthThresholds:    s.cfg.GetHealthThresholds().ToClientMs(),
@@ -457,7 +458,7 @@ func (s *Server) handleConfigClient(w http.ResponseWriter, r *http.Request) {
 		Tiles:               s.cfg.Tiles,
 		Customizer:          CustomizerClientConfig{DisabledTabs: disabledTabs},
 		ClientRxCoverage:    s.cfg.ClientRxCoverageEnabled(),
-		PathTrust:           func() *PathTrustConfig { pt := s.cfg.GetPathTrust(); return &pt }(),
+		PathTrust:           &pathTrust,
 	})
 }
 

--- a/cmd/server/types.go
+++ b/cmd/server/types.go
@@ -1044,6 +1044,7 @@ type ClientConfigResponse struct {
 	MapDarkTileProvider string                 `json:"mapDarkTileProvider,omitempty"` // deprecated. TODO: remove after v3.5.0
 	Customizer          CustomizerClientConfig `json:"customizer"`
 	ClientRxCoverage    bool                   `json:"clientRxCoverage"`
+	PathTrust           *PathTrustConfig       `json:"pathTrust,omitempty"`
 }
 
 // CustomizerClientConfig is the operator-side customizer-modal knobs that

--- a/config.example.json
+++ b/config.example.json
@@ -223,8 +223,8 @@
     "_comment_observerThresholds": "Observer health classification. Online: last_seen < observerOnlineMinutes ago. Stale: between Online and observerStaleMinutes. Offline: beyond observerStaleMinutes. Defaults 60 / 1440 (1h / 24h) match the node thresholds for consistency and eliminate flap on low-traffic / CDN-fronted instances (#1552). Operators who want the old aggressive 10-min Online threshold can set observerOnlineMinutes: 10."
   },
   "pathTrust": {
-    "minHashBytesForMapping": 1,
-    "_comment_pathTrust": "Minimum path-hash prefix length, in bytes, trusted as mapping/topology evidence (issue #1784). MeshCore path hops are hashed pubkey prefixes of 1, 2, or 3 bytes (firmware hash_size = (pathByte>>6)+1); valid range is 1-3. Default 1 is backward-compatible: all prefix lengths count as evidence. Set to 2 to exclude 1-byte prefixes (256-value collision space) from mapping evidence — recommended for denser meshes where short-prefix collisions cause false positives. Set to 3 for the strictest mode (only 3-byte evidence trusted). This does not affect raw storage — packets/paths are always stored as received."
+    "minHashBytesForMapping": 2,
+    "_comment_pathTrust": "Minimum path-hash prefix length, in bytes, trusted as mapping/topology evidence (issue #1784). MeshCore path hops are hashed pubkey prefixes of 1, 2, or 3 bytes (firmware hash_size = (pathByte>>6)+1); valid range is 1-3. Default 2 excludes 1-byte prefixes (256-value collision space) from mapping evidence — operator-confirmed to reduce false positives on denser meshes. Set to 1 for backward-compatible trust-all behavior. Set to 3 for the strictest mode (only 3-byte evidence trusted). This does not affect raw storage — packets/paths are always stored as received."
   },
   "defaultRegion": "SJC",
   "mapDefaults": {

--- a/config.example.json
+++ b/config.example.json
@@ -222,6 +222,10 @@
     "_comment": "How long (hours) before nodes show as degraded/silent. 'infra' = repeaters & rooms, 'node' = companions & others. relayActiveHours: a repeater is shown as 'actively relaying' if its pubkey appeared as a path hop in a non-advert packet within this window (issue #662).",
     "_comment_observerThresholds": "Observer health classification. Online: last_seen < observerOnlineMinutes ago. Stale: between Online and observerStaleMinutes. Offline: beyond observerStaleMinutes. Defaults 60 / 1440 (1h / 24h) match the node thresholds for consistency and eliminate flap on low-traffic / CDN-fronted instances (#1552). Operators who want the old aggressive 10-min Online threshold can set observerOnlineMinutes: 10."
   },
+  "pathTrust": {
+    "minHashBytesForMapping": 1,
+    "_comment_pathTrust": "Minimum path-hash prefix length, in bytes, trusted as mapping/topology evidence (issue #1784). MeshCore path hops are hashed pubkey prefixes of 1, 2, or 3 bytes (firmware hash_size = (pathByte>>6)+1); valid range is 1-3. Default 1 is backward-compatible: all prefix lengths count as evidence. Set to 2 to exclude 1-byte prefixes (256-value collision space) from mapping evidence — recommended for denser meshes where short-prefix collisions cause false positives. Set to 3 for the strictest mode (only 3-byte evidence trusted). This does not affect raw storage — packets/paths are always stored as received."
+  },
   "defaultRegion": "SJC",
   "mapDefaults": {
     "center": [

--- a/internal/packetpath/trust.go
+++ b/internal/packetpath/trust.go
@@ -20,7 +20,7 @@ type TrustConfig struct {
 	MinHashBytesForMapping int `json:"minHashBytesForMapping,omitempty"`
 }
 
-const DefaultMinHashBytesForMapping = 1
+const DefaultMinHashBytesForMapping = 2
 
 const MaxHashBytes = 3
 

--- a/internal/packetpath/trust.go
+++ b/internal/packetpath/trust.go
@@ -1,0 +1,58 @@
+package packetpath
+
+// TrustConfig controls how much confidence a path-hash prefix observation
+// must carry before it is used as topology/mapping evidence (issue #1784).
+//
+// MeshCore path hops are hashed pubkey prefixes of 1, 2, or 3 bytes
+// (firmware/src/Packet.cpp:13-18, hash_size = (pathByte>>6)+1). Shorter
+// prefixes collide more often — a 1-byte hash has only 256 possible values,
+// so on denser meshes a "currently unique candidate" resolution can still
+// be a false positive. TrustConfig lets operators require a longer prefix
+// before a mapping consumer (neighbor graph, path resolver, neighbor
+// builder, path inspector) treats a resolved hop as trustworthy evidence.
+//
+// This does not affect raw storage: packets and paths are always stored
+// exactly as received. It only gates *derived* trust — which observations
+// are eligible to become neighbor-graph edges, resolved-path hops, or
+// capability inferences. See the #1784 call-site audit for the full list
+// of consumers this is meant to gate.
+type TrustConfig struct {
+	MinHashBytesForMapping int `json:"minHashBytesForMapping,omitempty"`
+}
+
+const DefaultMinHashBytesForMapping = 1
+
+const MaxHashBytes = 3
+
+func (c *TrustConfig) MinHashBytesOrDefault() int {
+	if c == nil || c.MinHashBytesForMapping <= 0 {
+		return DefaultMinHashBytesForMapping
+	}
+	if c.MinHashBytesForMapping > MaxHashBytes {
+		return MaxHashBytes
+	}
+	return c.MinHashBytesForMapping
+}
+
+// MeetsPathTrust reports whether a path-hash observation of the given
+// prefix length (in bytes) should be trusted as mapping/topology evidence
+// under cfg's threshold.
+//
+// prefixBytes == 0 denotes an unknown-length/legacy observation — e.g.
+// pre-#1638 persisted neighbor edges with no per-mode breakdown
+// (NeighborEdge.CountsByMode[0] in cmd/server/neighbor_graph.go). Per
+// #1784's bucket-0 policy: once the threshold requires more than the
+// wire-format minimum of 1 byte (minBytes >= 2), an unknown-length
+// observation cannot be proven to meet it and is excluded. At the
+// trust-all threshold (minBytes <= 1) bucket 0 passes, matching pre-#1784
+// behavior exactly.
+func MeetsPathTrust(prefixBytes int, cfg *TrustConfig) bool {
+	minBytes := cfg.MinHashBytesOrDefault()
+	if minBytes <= 1 {
+		return true
+	}
+	if prefixBytes <= 0 {
+		return false
+	}
+	return prefixBytes >= minBytes
+}

--- a/internal/packetpath/trust.go
+++ b/internal/packetpath/trust.go
@@ -20,6 +20,8 @@ type TrustConfig struct {
 	MinHashBytesForMapping int `json:"minHashBytesForMapping,omitempty"`
 }
 
+// DefaultMinHashBytesForMapping excludes collision-prone 1-byte prefixes.
+// Operators can explicitly set 1 to retain legacy trust-all behavior.
 const DefaultMinHashBytesForMapping = 2
 
 const MaxHashBytes = 3

--- a/internal/packetpath/trust_test.go
+++ b/internal/packetpath/trust_test.go
@@ -3,13 +3,13 @@ package packetpath
 import "testing"
 
 func TestMeetsPathTrust_DefaultThreshold(t *testing.T) {
-	// nil cfg → DefaultMinHashBytesForMapping (1): trust-all, backward-compatible.
+	// nil cfg → DefaultMinHashBytesForMapping (2): 0-byte and 1-byte excluded.
 	cases := []struct {
 		prefixBytes int
 		want        bool
 	}{
-		{0, true},
-		{1, true},
+		{0, false},
+		{1, false},
 		{2, true},
 		{3, true},
 	}
@@ -49,14 +49,17 @@ func TestMeetsPathTrust_Exclude1Byte(t *testing.T) {
 }
 
 func TestMeetsPathTrust_ZeroValueOptIn(t *testing.T) {
-	// A zero-value MinHashBytesForMapping (unset) must fall back to default (1),
-	// so bucket-0 and 1-byte prefixes pass.
+	// A zero-value MinHashBytesForMapping (unset) must fall back to default (2),
+	// so bucket-0 and 1-byte prefixes fail; 2-byte and above pass.
 	cfg := &TrustConfig{}
-	if !MeetsPathTrust(1, cfg) {
-		t.Errorf("MeetsPathTrust(1, %+v) = false, want true (unset uses default=1, trust-all)", cfg)
+	if MeetsPathTrust(1, cfg) {
+		t.Errorf("MeetsPathTrust(1, %+v) = true, want false (unset uses default=2, 1-byte excluded)", cfg)
 	}
-	if !MeetsPathTrust(0, cfg) {
-		t.Errorf("MeetsPathTrust(0, %+v) = false, want true (bucket-0 passes at default threshold)", cfg)
+	if MeetsPathTrust(0, cfg) {
+		t.Errorf("MeetsPathTrust(0, %+v) = true, want false (bucket-0 excluded at default threshold)", cfg)
+	}
+	if !MeetsPathTrust(2, cfg) {
+		t.Errorf("MeetsPathTrust(2, %+v) = false, want true (2-byte passes at default threshold)", cfg)
 	}
 }
 

--- a/internal/packetpath/trust_test.go
+++ b/internal/packetpath/trust_test.go
@@ -1,0 +1,137 @@
+package packetpath
+
+import "testing"
+
+func TestMeetsPathTrust_DefaultThreshold(t *testing.T) {
+	// nil cfg → DefaultMinHashBytesForMapping (1): trust-all, backward-compatible.
+	cases := []struct {
+		prefixBytes int
+		want        bool
+	}{
+		{0, true},
+		{1, true},
+		{2, true},
+		{3, true},
+	}
+	for _, c := range cases {
+		if got := MeetsPathTrust(c.prefixBytes, nil); got != c.want {
+			t.Errorf("MeetsPathTrust(%d, nil) = %v, want %v", c.prefixBytes, got, c.want)
+		}
+	}
+}
+
+func TestMeetsPathTrust_TrustAllOptIn(t *testing.T) {
+	cfg := &TrustConfig{MinHashBytesForMapping: 1}
+	for _, prefixBytes := range []int{0, 1, 2, 3} {
+		if !MeetsPathTrust(prefixBytes, cfg) {
+			t.Errorf("MeetsPathTrust(%d, minBytes=1) = false, want true", prefixBytes)
+		}
+	}
+}
+
+func TestMeetsPathTrust_Exclude1Byte(t *testing.T) {
+	// minHashBytesForMapping: 2 — recommended for denser meshes.
+	cfg := &TrustConfig{MinHashBytesForMapping: 2}
+	cases := []struct {
+		prefixBytes int
+		want        bool
+	}{
+		{0, false},
+		{1, false},
+		{2, true},
+		{3, true},
+	}
+	for _, c := range cases {
+		if got := MeetsPathTrust(c.prefixBytes, cfg); got != c.want {
+			t.Errorf("MeetsPathTrust(%d, minBytes=2) = %v, want %v", c.prefixBytes, got, c.want)
+		}
+	}
+}
+
+func TestMeetsPathTrust_ZeroValueOptIn(t *testing.T) {
+	// A zero-value MinHashBytesForMapping (unset) must fall back to default (1),
+	// so bucket-0 and 1-byte prefixes pass.
+	cfg := &TrustConfig{}
+	if !MeetsPathTrust(1, cfg) {
+		t.Errorf("MeetsPathTrust(1, %+v) = false, want true (unset uses default=1, trust-all)", cfg)
+	}
+	if !MeetsPathTrust(0, cfg) {
+		t.Errorf("MeetsPathTrust(0, %+v) = false, want true (bucket-0 passes at default threshold)", cfg)
+	}
+}
+
+func TestMeetsPathTrust_ConservativeThreshold3(t *testing.T) {
+	cfg := &TrustConfig{MinHashBytesForMapping: 3}
+	cases := []struct {
+		prefixBytes int
+		want        bool
+	}{
+		{0, false},
+		{1, false},
+		{2, false},
+		{3, true},
+	}
+	for _, c := range cases {
+		if got := MeetsPathTrust(c.prefixBytes, cfg); got != c.want {
+			t.Errorf("MeetsPathTrust(%d, minBytes=3) = %v, want %v", c.prefixBytes, got, c.want)
+		}
+	}
+}
+
+func TestMinHashBytesOrDefault(t *testing.T) {
+	var nilCfg *TrustConfig
+	if got := nilCfg.MinHashBytesOrDefault(); got != DefaultMinHashBytesForMapping {
+		t.Errorf("nil.MinHashBytesOrDefault() = %d, want %d", got, DefaultMinHashBytesForMapping)
+	}
+	unset := &TrustConfig{}
+	if got := unset.MinHashBytesOrDefault(); got != DefaultMinHashBytesForMapping {
+		t.Errorf("unset.MinHashBytesOrDefault() = %d, want %d", got, DefaultMinHashBytesForMapping)
+	}
+	explicit := &TrustConfig{MinHashBytesForMapping: 1}
+	if got := explicit.MinHashBytesOrDefault(); got != 1 {
+		t.Errorf("explicit(1).MinHashBytesOrDefault() = %d, want 1", got)
+	}
+	explicit2 := &TrustConfig{MinHashBytesForMapping: 2}
+	if got := explicit2.MinHashBytesOrDefault(); got != 2 {
+		t.Errorf("explicit(2).MinHashBytesOrDefault() = %d, want 2", got)
+	}
+	negative := &TrustConfig{MinHashBytesForMapping: -5}
+	if got := negative.MinHashBytesOrDefault(); got != DefaultMinHashBytesForMapping {
+		t.Errorf("negative.MinHashBytesOrDefault() = %d, want %d (defensive fallback)", got, DefaultMinHashBytesForMapping)
+	}
+}
+
+func TestMinHashBytesOrDefault_ClampsAboveMax(t *testing.T) {
+	cases := []int{4, 5, 99}
+	for _, v := range cases {
+		cfg := &TrustConfig{MinHashBytesForMapping: v}
+		if got := cfg.MinHashBytesOrDefault(); got != MaxHashBytes {
+			t.Errorf("MinHashBytesForMapping: %d -> MinHashBytesOrDefault() = %d, want %d (clamped)", v, got, MaxHashBytes)
+		}
+	}
+}
+
+func TestMinHashBytesOrDefault_ExactlyMax(t *testing.T) {
+	cfg := &TrustConfig{MinHashBytesForMapping: MaxHashBytes}
+	if got := cfg.MinHashBytesOrDefault(); got != MaxHashBytes {
+		t.Errorf("MinHashBytesOrDefault() = %d, want %d (exactly max, no clamp needed)", got, MaxHashBytes)
+	}
+}
+
+func TestMeetsPathTrust_ClampedThresholdOnlyTrustsMaxBytes(t *testing.T) {
+	cfg := &TrustConfig{MinHashBytesForMapping: 99}
+	cases := []struct {
+		prefixBytes int
+		want        bool
+	}{
+		{0, false},
+		{1, false},
+		{2, false},
+		{3, true},
+	}
+	for _, c := range cases {
+		if got := MeetsPathTrust(c.prefixBytes, cfg); got != c.want {
+			t.Errorf("MeetsPathTrust(%d, minBytes=99->clamped) = %v, want %v", c.prefixBytes, got, c.want)
+		}
+	}
+}

--- a/public/customize-v2.js
+++ b/public/customize-v2.js
@@ -1604,7 +1604,7 @@
     try { on = localStorage.getItem('meshcore-hide-1byte-hops') === 'true'; } catch (_e) {}
     var trustThreshold = (typeof window.MC_getPathTrustThreshold === 'function')
       ? window.MC_getPathTrustThreshold()
-      : 1;
+      : 2;
     var trustDesc = trustThreshold >= 2
       ? '1-byte path-hash prefixes collide ~8-way at ~2k relays and are excluded from topology/mapping evidence (minHashBytesForMapping: ' + trustThreshold + '). Routes below this threshold show as speculative or are excluded. Change via pathTrust.minHashBytesForMapping in config.json.'
       : '1-byte path-hash prefixes collide ~8-way at ~2k relays — many polylines and rows they produce are visual noise. Hide them here without changing what\'s stored. Set pathTrust.minHashBytesForMapping in config.json to 2 or 3 for stricter server-side evidence requirements.';

--- a/public/customize-v2.js
+++ b/public/customize-v2.js
@@ -1602,6 +1602,12 @@
   function _renderHide1ByteHopsToggle() {
     var on = false;
     try { on = localStorage.getItem('meshcore-hide-1byte-hops') === 'true'; } catch (_e) {}
+    var trustThreshold = (typeof window.MC_getPathTrustThreshold === 'function')
+      ? window.MC_getPathTrustThreshold()
+      : 1;
+    var trustDesc = trustThreshold >= 2
+      ? '1-byte path observations are NOT trusted for topology/mapping (minHashBytesForMapping: ' + trustThreshold + '). Routes below this threshold show as speculative or hidden. Change via pathTrust.minHashBytesForMapping in config.json.'
+      : 'All path-hash byte lengths (1\u20133) are trusted for topology/mapping (default, backward-compatible). Set pathTrust.minHashBytesForMapping in config.json to 2 or 3 for stricter evidence requirements.';
     return '<p class="cust-section-title" style="font-size:14px;margin:16px 0 8px">Path Display</p>' +
       '<p class="cust-hint" style="font-size:12px;color:var(--text-muted);margin-bottom:8px">1-byte path-hash prefixes (firmware default) collide ~8-way at ~2k relays — many polylines and route-pattern rows they produce are visual noise. Hide them globally without changing what\'s stored.</p>' +
       '<div class="cust-field" style="display:flex;align-items:center;gap:8px">' +
@@ -1609,7 +1615,8 @@
           (on ? ' checked' : '') +
           ' style="width:16px;height:16px;cursor:pointer">' +
         '<label for="cv2-hide-1byte-hops" style="cursor:pointer;margin:0">Hide short (1-byte) path-hash hops</label>' +
-      '</div>';
+      '</div>' +
+      '<p class="cust-hint" style="font-size:12px;color:var(--text-muted);margin:6px 0 0">' + trustDesc + '</p>';
   }
 
   // ── #1454 Show-encrypted-channels toggle ──

--- a/public/customize-v2.js
+++ b/public/customize-v2.js
@@ -1606,10 +1606,9 @@
       ? window.MC_getPathTrustThreshold()
       : 1;
     var trustDesc = trustThreshold >= 2
-      ? '1-byte path observations are NOT trusted for topology/mapping (minHashBytesForMapping: ' + trustThreshold + '). Routes below this threshold show as speculative or hidden. Change via pathTrust.minHashBytesForMapping in config.json.'
-      : 'All path-hash byte lengths (1\u20133) are trusted for topology/mapping (default, backward-compatible). Set pathTrust.minHashBytesForMapping in config.json to 2 or 3 for stricter evidence requirements.';
+      ? '1-byte path-hash prefixes collide ~8-way at ~2k relays and are excluded from topology/mapping evidence (minHashBytesForMapping: ' + trustThreshold + '). Routes below this threshold show as speculative or are excluded. Change via pathTrust.minHashBytesForMapping in config.json.'
+      : '1-byte path-hash prefixes collide ~8-way at ~2k relays — many polylines and rows they produce are visual noise. Hide them here without changing what\'s stored. Set pathTrust.minHashBytesForMapping in config.json to 2 or 3 for stricter server-side evidence requirements.';
     return '<p class="cust-section-title" style="font-size:14px;margin:16px 0 8px">Path Display</p>' +
-      '<p class="cust-hint" style="font-size:12px;color:var(--text-muted);margin-bottom:8px">1-byte path-hash prefixes (firmware default) collide ~8-way at ~2k relays — many polylines and route-pattern rows they produce are visual noise. Hide them globally without changing what\'s stored.</p>' +
       '<div class="cust-field" style="display:flex;align-items:center;gap:8px">' +
         '<input type="checkbox" id="cv2-hide-1byte-hops" data-cv2-hide-1byte-hops' +
           (on ? ' checked' : '') +

--- a/public/hop-filter.js
+++ b/public/hop-filter.js
@@ -48,13 +48,15 @@
   }
 
   // #1784 — server-side path trust threshold (minHashBytesForMapping).
-  // Falls back to 1 (trust-all, backward-compatible default) until
-  // MeshConfigReady resolves.
+  // Falls back to DefaultMinHashBytesForMapping (2) until MeshConfigReady
+  // resolves. Default 2 excludes 1-byte prefixes (256-value collision
+  // space) from mapping evidence — operator-confirmed to reduce false
+  // positives on denser meshes.
   function getPathTrustThreshold() {
     if (typeof window !== 'undefined' && typeof window.PATH_TRUST === 'number') {
       return window.PATH_TRUST;
     }
-    return 1; // DefaultMinHashBytesForMapping — trust-all
+    return 2;
   }
 
   // #1784 — whether a hop meets the server-side path trust threshold.

--- a/public/hop-filter.js
+++ b/public/hop-filter.js
@@ -10,6 +10,13 @@
  * Wire & store stay intact: every consumer call site reads the toggle
  * via window.MC_getHide1ByteHops() and filters its rendered/aggregated
  * view at the boundary (no upstream mutation).
+ *
+ * #1784 — path trust threshold: the server-side config
+ * (pathTrust.minHashBytesForMapping, default 2) means 1-byte prefix
+ * observations are excluded from topology/mapping evidence. The
+ * MC_getPathTrustThreshold() function exposes this value so consumers
+ * can show "route could not be resolved (1-byte path)" messages instead
+ * of drawing potentially false paths.
  */
 'use strict';
 
@@ -38,6 +45,41 @@
     if (h == null) return 0;
     var s = String(h);
     return s.length >> 1;
+  }
+
+  // #1784 — server-side path trust threshold (minHashBytesForMapping).
+  // Falls back to 1 (trust-all, backward-compatible default) until
+  // MeshConfigReady resolves.
+  function getPathTrustThreshold() {
+    if (typeof window !== 'undefined' && typeof window.PATH_TRUST === 'number') {
+      return window.PATH_TRUST;
+    }
+    return 1; // DefaultMinHashBytesForMapping — trust-all
+  }
+
+  // #1784 — whether a hop meets the server-side path trust threshold.
+  // Used by map/analytics/path-inspect consumers to determine if a resolved
+  // hop should be treated as trusted evidence or speculative.
+  function meetsPathTrust(hop) {
+    var threshold = getPathTrustThreshold();
+    if (threshold <= 1) return true;
+    var bl = hopByteLen(hop);
+    if (bl <= 0) return false;
+    return bl >= threshold;
+  }
+
+  // #1784 — whether a packet's path observations are entirely below the
+  // trust threshold. When true, derived consumers should show a clear
+  // message like "Could not accurately determine route (N-byte path)"
+  // instead of drawing potentially false paths.
+  function pathBelowTrust(hops) {
+    if (!hops || !hops.length) return false;
+    var threshold = getPathTrustThreshold();
+    if (threshold <= 1) return false;
+    for (var i = 0; i < hops.length; i++) {
+      if (hopByteLen(hops[i]) >= threshold) return false;
+    }
+    return true;
   }
 
   // Packet-level path-hash size (1|2|3), or 0 when unresolvable.
@@ -95,6 +137,9 @@
     window.MC_filterPathHops = filterPathHops;
     window.MC_hopByteLen = hopByteLen;
     window.MC_packetHashSize = packetHashSize;
+    window.MC_getPathTrustThreshold = getPathTrustThreshold;
+    window.MC_meetsPathTrust = meetsPathTrust;
+    window.MC_pathBelowTrust = pathBelowTrust;
   }
 
   if (typeof module !== 'undefined' && module.exports) {
@@ -105,6 +150,9 @@
       filterPathHops: filterPathHops,
       hopByteLen: hopByteLen,
       packetHashSize: packetHashSize,
+      getPathTrustThreshold: getPathTrustThreshold,
+      meetsPathTrust: meetsPathTrust,
+      pathBelowTrust: pathBelowTrust,
       _STORAGE_KEY: STORAGE_KEY
     };
   }

--- a/public/roles.js
+++ b/public/roles.js
@@ -604,6 +604,11 @@
       : { disabledTabs: [] };
     // #1574 — operator-configurable cap on /live map node count.
     if (cfg.liveMapMaxNodes != null) window.LIVE_MAP_MAX_NODES = cfg.liveMapMaxNodes;
+    // #1784 — path trust threshold: minimum hash bytes for mapping evidence.
+    // Default 2 means 1-byte observations are excluded from topology/mapping.
+    window.PATH_TRUST = cfg.pathTrust && cfg.pathTrust.minHashBytesForMapping
+      ? cfg.pathTrust.minHashBytesForMapping
+      : 1; // DefaultMinHashBytesForMapping — trust-all (backward-compatible)
     // Sync ROLE_STYLE colors with ROLE_COLORS
     // #1407 — both are now live getters; no manual sync needed. Kept as no-op for clarity.
   }).catch(function () { /* use defaults */ });

--- a/public/roles.js
+++ b/public/roles.js
@@ -608,7 +608,7 @@
     // Default 2 means 1-byte observations are excluded from topology/mapping.
     window.PATH_TRUST = cfg.pathTrust && cfg.pathTrust.minHashBytesForMapping
       ? cfg.pathTrust.minHashBytesForMapping
-      : 1; // DefaultMinHashBytesForMapping — trust-all (backward-compatible)
+      : 2;
     // Sync ROLE_STYLE colors with ROLE_COLORS
     // #1407 — both are now live getters; no manual sync needed. Kept as no-op for clarity.
   }).catch(function () { /* use defaults */ });

--- a/test-issue-1633-hide-1byte-hops.js
+++ b/test-issue-1633-hide-1byte-hops.js
@@ -450,12 +450,12 @@ test('[kb #1] anti-tautology: tests reference the actual production files (not i
 
 console.log('\n=== #1784: path trust threshold ===');
 
-test('#1784: MC_getPathTrustThreshold default is 1 (backward-compatible)', () => {
+test('#1784: MC_getPathTrustThreshold default is 2 (operator-confirmed)', () => {
   const ctx = makeSandbox();
   load(ctx, 'public/hop-filter.js');
   delete ctx.window.PATH_TRUST;
-  assert.strictEqual(ctx.window.MC_getPathTrustThreshold(), 1,
-    'default path trust threshold must be 1 (trust-all)');
+  assert.strictEqual(ctx.window.MC_getPathTrustThreshold(), 2,
+    'default path trust threshold must be 2 (operator-confirmed, excludes 1-byte)');
 });
 
 test('#1784: MC_getPathTrustThreshold reads window.PATH_TRUST', () => {

--- a/test-issue-1633-hide-1byte-hops.js
+++ b/test-issue-1633-hide-1byte-hops.js
@@ -444,5 +444,98 @@ test('[kb #1] anti-tautology: tests reference the actual production files (not i
   );
 });
 
+// ─────────────────────────────────────────────────────────────────────
+// #1784 path trust threshold — configurable minimum hash bytes for mapping
+// ─────────────────────────────────────────────────────────────────────
+
+console.log('\n=== #1784: path trust threshold ===');
+
+test('#1784: MC_getPathTrustThreshold default is 1 (backward-compatible)', () => {
+  const ctx = makeSandbox();
+  load(ctx, 'public/hop-filter.js');
+  delete ctx.window.PATH_TRUST;
+  assert.strictEqual(ctx.window.MC_getPathTrustThreshold(), 1,
+    'default path trust threshold must be 1 (trust-all)');
+});
+
+test('#1784: MC_getPathTrustThreshold reads window.PATH_TRUST', () => {
+  const ctx = makeSandbox();
+  load(ctx, 'public/hop-filter.js');
+  ctx.window.PATH_TRUST = 2;
+  assert.strictEqual(ctx.window.MC_getPathTrustThreshold(), 2,
+    'must return configured PATH_TRUST');
+  ctx.window.PATH_TRUST = 3;
+  assert.strictEqual(ctx.window.MC_getPathTrustThreshold(), 3,
+    'must return configured PATH_TRUST=3');
+});
+
+test('#1784: MC_meetsPathTrust with threshold 1 (trust-all)', () => {
+  const ctx = makeSandbox();
+  load(ctx, 'public/hop-filter.js');
+  ctx.window.PATH_TRUST = 1;
+  assert.strictEqual(ctx.window.MC_meetsPathTrust('AB'), true, '1-byte hop meets threshold 1');
+  assert.strictEqual(ctx.window.MC_meetsPathTrust('ABCD'), true, '2-byte hop meets threshold 1');
+  assert.strictEqual(ctx.window.MC_meetsPathTrust('ABCDEF'), true, '3-byte hop meets threshold 1');
+});
+
+test('#1784: MC_meetsPathTrust with threshold 2 (exclude 1-byte)', () => {
+  const ctx = makeSandbox();
+  load(ctx, 'public/hop-filter.js');
+  ctx.window.PATH_TRUST = 2;
+  assert.strictEqual(ctx.window.MC_meetsPathTrust('AB'), false, '1-byte hop excluded');
+  assert.strictEqual(ctx.window.MC_meetsPathTrust('ABCD'), true, '2-byte hop trusted');
+  assert.strictEqual(ctx.window.MC_meetsPathTrust('ABCDEF'), true, '3-byte hop trusted');
+});
+
+test('#1784: MC_meetsPathTrust with threshold 3 (strictest)', () => {
+  const ctx = makeSandbox();
+  load(ctx, 'public/hop-filter.js');
+  ctx.window.PATH_TRUST = 3;
+  assert.strictEqual(ctx.window.MC_meetsPathTrust('AB'), false, '1-byte excluded');
+  assert.strictEqual(ctx.window.MC_meetsPathTrust('ABCD'), false, '2-byte excluded');
+  assert.strictEqual(ctx.window.MC_meetsPathTrust('ABCDEF'), true, '3-byte trusted');
+});
+
+test('#1784: MC_pathBelowTrust all-1-byte path at threshold 2', () => {
+  const ctx = makeSandbox();
+  load(ctx, 'public/hop-filter.js');
+  ctx.window.PATH_TRUST = 2;
+  assert.strictEqual(ctx.window.MC_pathBelowTrust(['AB', '12']), true,
+    'all-1-byte path must be below trust');
+});
+
+test('#1784: MC_pathBelowTrust mixed path at threshold 2', () => {
+  const ctx = makeSandbox();
+  load(ctx, 'public/hop-filter.js');
+  ctx.window.PATH_TRUST = 2;
+  assert.strictEqual(ctx.window.MC_pathBelowTrust(['AB', 'CDEF']), false,
+    'mixed 1-byte/2-byte path must NOT be below trust');
+});
+
+test('#1784: MC_pathBelowTrust at threshold 1 (trust-all)', () => {
+  const ctx = makeSandbox();
+  load(ctx, 'public/hop-filter.js');
+  ctx.window.PATH_TRUST = 1;
+  assert.strictEqual(ctx.window.MC_pathBelowTrust(['AB']), false,
+    'no path below trust at threshold 1');
+});
+
+test('#1784: empty/null hops are not below trust', () => {
+  const ctx = makeSandbox();
+  load(ctx, 'public/hop-filter.js');
+  ctx.window.PATH_TRUST = 2;
+  assert.strictEqual(ctx.window.MC_pathBelowTrust(null), false, 'null → not below trust');
+  assert.strictEqual(ctx.window.MC_pathBelowTrust([]), false, 'empty → not below trust');
+});
+
+test('#1784: MC_meetsPathTrust handles null/undefined safely', () => {
+  const ctx = makeSandbox();
+  load(ctx, 'public/hop-filter.js');
+  ctx.window.PATH_TRUST = 2;
+  assert.strictEqual(ctx.window.MC_meetsPathTrust(null), false, 'null → false (byteLen 0 < 2)');
+  assert.strictEqual(ctx.window.MC_meetsPathTrust(undefined), false, 'undefined → false');
+  assert.strictEqual(ctx.window.MC_meetsPathTrust(''), false, 'empty string → false');
+});
+
 console.log('\n' + passed + ' passed, ' + failed + ' failed');
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Step 3 of the #1784 multi-PR project. It wires `packetpath.MeetsPathTrust` into neighbor-graph construction and path inspection, exposes the effective threshold through `/api/config/client`, and provides shared frontend helpers.

**Depends on:** #1824. This branch carries the foundation files for compilation and must be rebased after #1824 merges.

## Default behavior

The default `pathTrust.minHashBytesForMapping` is **2**. Installations without a `pathTrust` block exclude 1-byte prefixes from derived mapping and topology evidence, reducing collision-driven false positives. Raw packets and paths are never filtered.

Set the value to `1` to retain the legacy trust-all behavior, or `3` to require only 3-byte evidence.

```json
"pathTrust": { "minHashBytesForMapping": 1 }
```

## Changes

- Neighbor-graph construction skips observations below the effective trust threshold.
- Path inspection exposes per-hop `trusted` evidence and reports the active threshold.
- `/api/config/client` serializes the effective `pathTrust` value for frontend consumers.
- Shared frontend helpers evaluate hop and path trust consistently.
- The customizer explains the active trust policy.

## Testing

- Unit tests cover threshold clamping, nil safety, and default behavior.
- Neighbor-graph tests cover 1-byte exclusion at the default and explicit threshold boundaries.
- Frontend tests cover trust helper behavior.
