### PR TITLE
perf: prune lastSeenTouched map during eviction, remove dead relayTimes field

### DIFF
--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -177,7 +177,6 @@ type PacketStore struct {
 	byNode        map[string][]*StoreTx      // pubkey → transmissions
 	nodeHashes    map[string]map[string]bool // pubkey → Set<hash>
 	byPathHop     map[string][]*StoreTx      // lowercase hop/pubkey → transmissions with that hop in path
-	relayTimes    map[string][]int64         // lowercase pubkey → sorted unix-millis of relay events (full pubkeys only)
 	byPayloadType map[int][]*StoreTx         // payload_type → transmissions
 	loaded        bool
 	totalObs      int
@@ -644,7 +643,6 @@ func NewPacketStore(db *DB, cfg *PacketStoreConfig, cacheTTLs ...map[string]inte
 		byObserver:    make(map[string][]*StoreObs),
 		byNode:        make(map[string][]*StoreTx),
 		byPathHop:     make(map[string][]*StoreTx),
-		relayTimes:    make(map[string][]int64),
 		nodeHashes:    make(map[string]map[string]bool),
 		byPayloadType: make(map[int][]*StoreTx),
 		rfCache:       make(map[string]*cachedResult),
@@ -4791,6 +4789,19 @@ func (s *PacketStore) evictStaleInternal(rpBatch map[int][]string) int {
 	// Compact resolved pubkey index after eviction sweep
 	s.CompactResolvedPubkeyIndex()
 	s.CheckResolvedPubkeyIndexSize()
+
+	// Prune lastSeenTouched: remove entries older than the debounce window
+	// (5 minutes). This map grows unbounded as new relay pubkeys are seen;
+	// without pruning, a long-running instance accumulates one entry per
+	// unique pubkey ever observed, even after those nodes are evicted.
+	if len(s.lastSeenTouched) > 0 {
+		debounceCutoff := time.Now().Add(-5 * time.Minute)
+		for pk, ts := range s.lastSeenTouched {
+			if ts.Before(debounceCutoff) {
+				delete(s.lastSeenTouched, pk)
+			}
+		}
+	}
 
 	return evictCount
 }

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -1751,8 +1751,6 @@ func (s *PacketStore) touchRelayLastSeen(resolvedPubkeys []string, now time.Time
 	if s.db == nil || len(resolvedPubkeys) == 0 {
 		return
 	}
-	const debounceInterval = 5 * time.Minute
-
 	ts := now.UTC().Format(time.RFC3339)
 	seen := make(map[string]bool, len(resolvedPubkeys))
 	for _, pk := range resolvedPubkeys {
@@ -1760,7 +1758,7 @@ func (s *PacketStore) touchRelayLastSeen(resolvedPubkeys []string, now time.Time
 			continue
 		}
 		seen[pk] = true
-		if last, ok := s.lastSeenTouched[pk]; ok && now.Sub(last) < debounceInterval {
+		if last, ok := s.lastSeenTouched[pk]; ok && now.Sub(last) < relayLastSeenDebounceInterval {
 			continue
 		}
 		if err := s.db.TouchNodeLastSeen(pk, ts); err == nil {
@@ -4414,6 +4412,11 @@ const (
 	// Per-tx map overhead (obsKeys + observerSet): map header + initial buckets
 	perTxMapsBytes = 200
 
+	// relayLastSeenDebounceInterval is the minimum interval between
+	// TouchNodeLastSeen DB writes for the same pubkey. Entries in
+	// lastSeenTouched older than this interval are pruned during eviction.
+	relayLastSeenDebounceInterval = 5 * time.Minute
+
 	// Per path hop: byPathHop index entry (pointer + map bucket)
 	perPathHopBytes = 50
 
@@ -4795,7 +4798,7 @@ func (s *PacketStore) evictStaleInternal(rpBatch map[int][]string) int {
 	// without pruning, a long-running instance accumulates one entry per
 	// unique pubkey ever observed, even after those nodes are evicted.
 	if len(s.lastSeenTouched) > 0 {
-		debounceCutoff := time.Now().Add(-5 * time.Minute)
+		debounceCutoff := time.Now().Add(-relayLastSeenDebounceInterval)
 		for pk, ts := range s.lastSeenTouched {
 			if ts.Before(debounceCutoff) {
 				delete(s.lastSeenTouched, pk)


### PR DESCRIPTION
## Problem

Two memory issues in `PacketStore`:

1. **`lastSeenTouched` grows unbounded**: This map debounces `last_seen` DB writes for relay nodes (1 entry per unique pubkey). Entries are never removed, even after those nodes are evicted from the store. Over months of operation with thousands of relay nodes, this map accumulates thousands of stale entries.

2. **`relayTimes` is dead code**: The field is declared (`map[string][]int64`) and initialized (`make(map[string][]int64)`) but never populated or read in production code. The `addTxToRelayTimeIndex` function and its tests operate on locally-passed maps, not the struct field.

## Fix

1. **Prune `lastSeenTouched` during eviction**: After each eviction pass, remove entries older than the 5-minute debounce window. This bounds the map to only recently-active relay nodes.

2. **Remove `relayTimes` field**: Delete the declaration and initialization. The `addTxToRelayTimeIndex` function and tests are unaffected (they use their own local maps).

## Testing
- `go build` passes
- No behavior change — `relayTimes` was never used, `lastSeenTouched` pruning only removes entries that are past the debounce window (no functional impact)