### PR TITLE
fix: use index from_pubkey in nodes region filter

### DIFF
--- a/cmd/server/db.go
+++ b/cmd/server/db.go
@@ -903,8 +903,11 @@ func (db *DB) GetNodes(limit, offset int, role, search, before, lastHeard, sortB
 			if !db.isV3 {
 				joinCond = "obs.id = o.observer_id"
 			}
+			// #1143: from_pubkey is a dedicated, indexed column populated at
+			// ingest (and backfilled) for ADVERT rows specifically so pubkey
+			// lookups don't need to JSON_EXTRACT + parse decoded_json per row.
 			subq := fmt.Sprintf(`public_key IN (
-				SELECT DISTINCT JSON_EXTRACT(t.decoded_json, '$.pubKey')
+				SELECT DISTINCT t.from_pubkey
 				FROM transmissions t
 				JOIN observations o ON o.transmission_id = t.id
 				JOIN observers obs ON %s


### PR DESCRIPTION
The region subquery in GetNodes was pulling the advert pubkey out of decoded_json with JSON_EXTRACT for every row the join touched, instead of reading the from_pubkey column that #1143 already added and indexed

It looks like buildPacketWhere, GetRecentTransmissionsForNode, QueryMultiNodePackets etc. moved to from_pubkey already, but not this.