### PR TITLE
fix(#1904): keep resolved full-pubkey hops across a path-hop index rebuild

### DIFF
--- a/cmd/server/pathhop_rebuild_1904_test.go
+++ b/cmd/server/pathhop_rebuild_1904_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+// Issue #1904: buildPathHopIndex() rebuilds byPathHop from raw path_json
+// hops and opens by discarding the map. But byPathHop also holds resolved
+// full-pubkey keys fed by indexResolvedPathHops, and those pubkey strings
+// are retained nowhere (#800 dropped the per-StoreTx ResolvedPath field in
+// favour of a hash-only index), so a plain rebuild silently drops every
+// resolved attribution. On a cold start that leaves relay_count_*,
+// last_relayed and transported_scopes empty for every node until live
+// ingestion refills the index.
+//
+// The rebuild must therefore RETAIN resolved entries — but only for
+// transmissions still in s.packets. Eviction's removeTxFromPathHopIndex
+// only strips raw hops (it derives them from txGetParsedPath), so evicted
+// transmissions linger under their resolved keys; the rebuild is where
+// they get dropped.
+
+const (
+	hop1904Raw      = "a3"
+	hop1904Resolved = "a3f19c2b7d4e5081aa22bb33cc44dd55ee66ff778899000112233445566778899"
+	hop1904Evicted  = "b7002211ffeeddccbbaa99887766554433221100aabbccddeeff001122334455"
+)
+
+// pathHopTx builds a transmission whose wire path is a single raw hop.
+func pathHopTx(id int, path string) *StoreTx {
+	return &StoreTx{ID: id, Hash: "pathhop-tx-" + path, PathJSON: `["` + hop1904Raw + `"]`}
+}
+
+func newPathHopStore(packets []*StoreTx, idx map[string][]*StoreTx) *PacketStore {
+	return &PacketStore{packets: packets, byPathHop: idx, mu: sync.RWMutex{}}
+}
+
+func hopKeyHas(idx map[string][]*StoreTx, key string, tx *StoreTx) bool {
+	for _, t := range idx[key] {
+		if t == tx {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBuildPathHopIndex_RetainsResolvedHops_1904(t *testing.T) {
+	tx := pathHopTx(1, hop1904Raw)
+	// Shape produced by a chunk scan: raw hop from path_json PLUS the
+	// resolved full pubkey that indexResolvedPathHops added.
+	store := newPathHopStore([]*StoreTx{tx}, map[string][]*StoreTx{
+		hop1904Raw:      {tx},
+		hop1904Resolved: {tx},
+	})
+
+	store.buildPathHopIndex()
+
+	if !hopKeyHas(store.byPathHop, hop1904Raw, tx) {
+		t.Fatalf("raw hop %q lost by rebuild", hop1904Raw)
+	}
+	if !hopKeyHas(store.byPathHop, hop1904Resolved, tx) {
+		t.Fatalf("resolved pubkey hop %q dropped by rebuild — #1904", hop1904Resolved)
+	}
+}
+
+func TestBuildPathHopIndex_DropsResolvedHopsOfEvictedTx_1904(t *testing.T) {
+	live := pathHopTx(1, hop1904Raw)
+	evicted := pathHopTx(2, hop1904Raw) // NOT in s.packets any more
+
+	store := newPathHopStore([]*StoreTx{live}, map[string][]*StoreTx{
+		hop1904Raw:      {live},
+		hop1904Resolved: {live},
+		hop1904Evicted:  {evicted},
+	})
+
+	store.buildPathHopIndex()
+
+	if hopKeyHas(store.byPathHop, hop1904Evicted, evicted) {
+		t.Fatal("evicted transmission retained under its resolved key — the rebuild must not turn eviction's known gap into a permanent leak")
+	}
+	if _, ok := store.byPathHop[hop1904Evicted]; ok {
+		t.Fatalf("empty key %q left behind after dropping its only entry", hop1904Evicted)
+	}
+	if !hopKeyHas(store.byPathHop, hop1904Resolved, live) {
+		t.Fatal("live resolved hop dropped while pruning evicted ones")
+	}
+}
+
+func TestBuildPathHopIndex_NoDuplicateOnRepeatedBuild_1904(t *testing.T) {
+	tx := pathHopTx(1, hop1904Raw)
+	store := newPathHopStore([]*StoreTx{tx}, map[string][]*StoreTx{
+		hop1904Raw:      {tx},
+		hop1904Resolved: {tx},
+	})
+
+	store.buildPathHopIndex()
+	store.buildPathHopIndex()
+
+	if got := len(store.byPathHop[hop1904Raw]); got != 1 {
+		t.Fatalf("raw hop bucket has %d entries after two builds, want 1", got)
+	}
+	if got := len(store.byPathHop[hop1904Resolved]); got != 1 {
+		t.Fatalf("resolved hop bucket has %d entries after two builds, want 1", got)
+	}
+}

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -4046,14 +4046,81 @@ func (s *PacketStore) buildSubpathIndex() {
 		len(s.spIndex), s.spTotalPaths)
 }
 
-// buildPathHopIndex scans all packets and populates byPathHop.
+// buildPathHopIndex rebuilds byPathHop: raw wire hops from every packet's
+// path_json, plus the resolved full-pubkey hops carried over from the
+// previous index (see retainResolvedPathHops).
 // Must be called with s.mu held.
 func (s *PacketStore) buildPathHopIndex() {
-	s.byPathHop = make(map[string][]*StoreTx, 4096)
+	prev := s.byPathHop
+	s.byPathHop = make(map[string][]*StoreTx, max(4096, len(prev)))
 	for _, tx := range s.packets {
 		addTxToPathHopIndex(s.byPathHop, tx)
 	}
-	log.Printf("[store] Built path-hop index: %d unique keys", len(s.byPathHop))
+	retained := s.retainResolvedPathHops(prev)
+	log.Printf("[store] Built path-hop index: %d unique keys (%d resolved-hop entries retained)",
+		len(s.byPathHop), retained)
+}
+
+// retainResolvedPathHops re-merges the entries of a pre-rebuild byPathHop
+// that the raw-hop pass above cannot reproduce: the resolved full-pubkey
+// keys fed by indexResolvedPathHops. Their pubkey strings are retained
+// nowhere — #800 dropped the per-StoreTx ResolvedPath field in favour of a
+// hash-only membership index — so a plain rebuild silently discarded every
+// resolved relay attribution, leaving relay counts and transported scopes
+// empty after each cold load until live ingestion refilled them (#1904).
+//
+// Only transmissions still in s.packets are carried over. This matters:
+// eviction's removeTxFromPathHopIndex strips raw hops only (it derives them
+// from txGetParsedPath), so evicted transmissions linger in prev under their
+// resolved keys. Filtering them here is what keeps the index bounded by the
+// eviction policy instead of turning that gap into a permanent leak.
+//
+// Cost is O(entries in prev) with one reused scratch map, and it runs only
+// where buildPathHopIndex already runs — cold load and background-fill
+// completion — never on an ingest or request path.
+//
+// Returns the number of entries carried over. Must be called with s.mu held,
+// after s.byPathHop has been rebuilt from raw hops.
+func (s *PacketStore) retainResolvedPathHops(prev map[string][]*StoreTx) int {
+	if len(prev) == 0 {
+		return 0
+	}
+	live := make(map[*StoreTx]struct{}, len(s.packets))
+	for _, tx := range s.packets {
+		live[tx] = struct{}{}
+	}
+
+	// Reused across keys (cleared per key) so a large index does not churn
+	// one map allocation per key. Guards against both a key that the raw
+	// pass already produced and repeated appends of the same tx in prev —
+	// indexResolvedPathHops dedups within a call, not across the several
+	// observations of one transmission.
+	seen := make(map[*StoreTx]struct{}, 16)
+	retained := 0
+	for key, list := range prev {
+		if len(list) == 0 {
+			continue
+		}
+		clear(seen)
+		for _, tx := range s.byPathHop[key] {
+			seen[tx] = struct{}{}
+		}
+		for _, tx := range list {
+			if tx == nil {
+				continue
+			}
+			if _, ok := live[tx]; !ok {
+				continue
+			}
+			if _, dup := seen[tx]; dup {
+				continue
+			}
+			seen[tx] = struct{}{}
+			s.byPathHop[key] = append(s.byPathHop[key], tx)
+			retained++
+		}
+	}
+	return retained
 }
 
 // addTxToPathHopIndex indexes a transmission under each unique raw hop key.


### PR DESCRIPTION
Fixes #1904.

## The bug

`buildPathHopIndex` reassigned `s.byPathHop` to a fresh map and refilled it from every packet's raw `path_json` hops:

```go
func (s *PacketStore) buildPathHopIndex() {
	s.byPathHop = make(map[string][]*StoreTx, 4096)
	for _, tx := range s.packets {
		addTxToPathHopIndex(s.byPathHop, tx)   // raw hops only
	}
	...
}
```

`byPathHop` carries two kinds of key, though: those raw wire hops, and the resolved full pubkeys fed per observation by `indexResolvedPathHops`. The pubkey strings behind the second kind are retained nowhere — #800 replaced the per-`StoreTx` `ResolvedPath` field with a hash-only membership index (`resolvedPubkeyIndex` stores FNV hashes, not strings) — so the rebuild could not reproduce them and dropped them.

All three call sites run post-load: `LoadChunked` (`chunked_load.go:459`), the background fill loader (`store.go:1573`), and the deferred startup build (`index_ready_1008.go:177`). The `resolved_path` branch of the chunk scan populates the index and is then silently undone a few hundred lines later, while the `resolved_path IS NULL` fallback right beside it is explicitly documented as "byNode ONLY — the resolved_path/path-hop indexes must NOT be populated here". The two branches disagreed about who owns the index.

Consequence: after a cold start every lookup keyed by a node's full pubkey missed, so `relay_count_1h/24h`, `last_relayed`, `unscoped_relay_count_24h`, `transported_scopes` (#1751) and the usefulness Traffic axis all read zero until live ingestion slowly refilled the index.

## Evidence

Fixture built from live data: 2512 nodes, 17,056 transmissions, 528,891 observations, 123,057 of them carrying a non-NULL `resolved_path`.

```
before   [store] Built path-hop index: 2924 unique keys
         /api/nodes → 0 of 2000 nodes with transported_scopes
                      0 with relay_count_24h > 0

after    [store] Built path-hop index: 3881 unique keys
                      (172181 resolved-hop entries retained)
         /api/nodes → 726 with transported_scopes
                      741 with relay_count_24h > 0
```

The 957 extra keys are the full pubkeys.

## The change

`retainResolvedPathHops` re-merges the pre-rebuild map's entries that the raw-hop pass cannot reproduce.

Entries are carried over **only for transmissions still in `s.packets`**. That filter is load-bearing rather than defensive. `removeTxFromPathHopIndex` strips raw hops only — it derives them from `txGetParsedPath` — and its companion `removeFromResolvedPubkeyIndex` cleans the hash index, not `byPathHop`. So evicted transmissions linger under their resolved keys, and the wipe this PR removes was the only thing that ever cleared them. Filtering on liveness keeps the index bounded by the eviction policy instead of converting that gap into a permanent leak. `TestBuildPathHopIndex_DropsResolvedHopsOfEvictedTx_1904` pins it.

(The eviction gap itself is pre-existing and outside this change: between rebuilds, an evicted transmission still stays referenced under its resolved keys. Filed separately.)

## Perf

`O(entries in prev)` with one scratch map reused across keys (`clear()` per key, the same idiom as `hopsSeen`), plus one `map[*StoreTx]struct{}` over `s.packets` for the liveness check. It runs only where `buildPathHopIndex` already ran — cold load and background-fill completion — never on an ingest or request path. Measured on the fixture above: index build stayed within the same `LoadChunked` step, 15.2s total for 17k transmissions / 527k observations.

Memory: the retained entries point at transmissions already held by `s.packets`, so no `StoreTx` is kept alive beyond eviction; the cost is map/slice overhead for keys that the feature is supposed to have.

## Tests

`cmd/server/pathhop_rebuild_1904_test.go`, red before / green after:

1. `TestBuildPathHopIndex_RetainsResolvedHops_1904` — a resolved full-pubkey key survives the rebuild alongside the raw hop.
2. `TestBuildPathHopIndex_DropsResolvedHopsOfEvictedTx_1904` — a resolved key whose transmission is no longer in `s.packets` is dropped, and the now-empty key is not left behind.
3. `TestBuildPathHopIndex_NoDuplicateOnRepeatedBuild_1904` — building twice does not double-append (`indexResolvedPathHops` dedups within a call, not across the several observations of one transmission, so `prev` can legitimately contain duplicates).

```
cd cmd/server && go test ./...    ok  github.com/corescope/server  85.5s
go vet ./...                      clean
```

Frontend and ingestor suites are untouched by this change (Go server only, no `public/` files).

## Interaction with #1903

Both touch `byPathHop` semantics, so I verified them composed on the same fixture. With #1904 alone the resolved keys come back and #1902's prefix collision is plainly visible again (51% of 1-byte prefix groups reporting an identical scope set). With both:

```
f79616  BE repeater      ['#be','#de','#eu','#nl']   relay24h=542
f752c2  DE/NRW repeater  ['#de','#de-nw']            relay24h=343
f788ad  BE repeater      none                        relay24h=383
```

Identical-set prefix groups fall to 8%, relay counts stay intact, and each node's scopes match what its own `resolved_path` rows say. The two changes are independent and compose cleanly.
