### PR TITLE
fix(map): render an unobserved hash size as unknown, not as 1 byte

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -237,6 +237,7 @@
     "getTimestampMode": "readonly",
     "getTimestampTimezone": "readonly",
     "global": "readonly",
+    "hashPrefixInfo": "readonly",
     "initGeoFilterOverlay": "readonly",
     "initTabBar": "readonly",
     "invalidateApiCache": "readonly",

--- a/public/map.js
+++ b/public/map.js
@@ -141,16 +141,20 @@
   }
 
   function makeRepeaterLabelIcon(node, isStale, isAlsoObserver, mbStatus) {
-    var hs = node.hash_size || 1;
-    // Show the short mesh hash ID (first N bytes of pubkey, uppercased)
-    var shortHash = node.public_key ? node.public_key.slice(0, hs * 2).toUpperCase() : '??';
+    // Show the short mesh hash ID (first N bytes of pubkey, uppercased). When
+    // the width is unobserved the label falls back to one byte — it has to draw
+    // something — but says so instead of asserting a 1-byte config.
+    var hashInfo = hashPrefixInfo(node);
+    var shortHash = hashInfo.prefix;
+    var unknownWidth = hashInfo.known ? '' : ' hash-unconfirmed';
     // #1356 V3: glyph is the primary non-color status carrier, hash is the data,
     // status color is a thin left-border (CSS class drives the hue).
     var status = mbStatus || null;
     var glyph = status ? (MB_GLYPHS[status] || MB_GLYPHS.unknown) : '';
     var statusClass = status ? (' ' + (MB_STATUS_CLASS[status] || MB_STATUS_CLASS.unknown)) : '';
-    var ariaStatus = status ? ('multi-byte ' + status + ', hash ' + shortHash)
-                            : ('repeater hash ' + shortHash);
+    var ariaWidth = hashInfo.known ? '' : ', hash size unknown';
+    var ariaStatus = status ? ('multi-byte ' + status + ', hash ' + shortHash + ariaWidth)
+                            : ('repeater hash ' + shortHash + ariaWidth);
     // Observer indicator stays a star — it is an orthogonal signal, not a status color.
     var obsIndicator = isAlsoObserver
       ? ' <span aria-hidden="true" style="color:' + (ROLE_COLORS.observer || '#f1c40f') + ';font-size:13px;line-height:1;" title="Also an observer"><svg class="ph-icon" aria-hidden="true"><use href="/icons/phosphor-sprite.svg#ph-star-fill"/></svg></span>'
@@ -158,7 +162,7 @@
     // Glyph + thin-space (U+2009) + hash. Visible content is aria-hidden so AT
     // reads the aria-label only (avoids "check mark 3 E" literal announcements).
     var visible = (glyph ? glyph + '\u2009' : '') + shortHash;
-    var html = '<div class="mc-mb-label' + statusClass + '" role="img" aria-label="' + ariaStatus + '">' +
+    var html = '<div class="mc-mb-label' + statusClass + unknownWidth + '" role="img" aria-label="' + ariaStatus + '">' +
       '<span aria-hidden="true">' + visible + '</span>' + obsIndicator + '</div>';
     return L.divIcon({
       html: html,
@@ -200,6 +204,7 @@
               <button class="btn ${filters.byteSize==='1'?'active':''}" data-byte="1">1-byte</button>
               <button class="btn ${filters.byteSize==='2'?'active':''}" data-byte="2">2-byte</button>
               <button class="btn ${filters.byteSize==='3'?'active':''}" data-byte="3">3-byte</button>
+              <button class="btn ${filters.byteSize==='unknown'?'active':''}" data-byte="unknown" title="No advert-derived hash size in the retention window">Unknown</button>
             </div>
           </fieldset>
           <fieldset class="mc-section">
@@ -1668,10 +1673,16 @@
     const filtered = nodes.filter(n => {
       if (!n.lat || !n.lon) return false;
       if (!filters[n.role || 'companion']) return false;
-      // Byte size filter (applies only to repeaters)
+      // Byte size filter (applies only to repeaters). A node with no observed
+      // size is its own bucket — folding it into "1-byte" made that bucket a
+      // mix of measured and merely-unheard nodes.
       if (filters.byteSize !== 'all' && (n.role || 'companion') === 'repeater') {
-        const hs = n.hash_size || 1;
-        if (String(hs) !== filters.byteSize) return false;
+        const hi = hashPrefixInfo(n);
+        if (filters.byteSize === 'unknown') {
+          if (hi.known) return false;
+        } else if (!hi.known || String(hi.bytes) !== filters.byteSize) {
+          return false;
+        }
       }
       // Status filter
       if (filters.statusFilter !== 'all') {
@@ -1855,10 +1866,14 @@
     // Check if this node is also an observer (combined repeater+observer)
     const matchingObs = node.public_key ? _observerByPubkey.get(node.public_key.toLowerCase()) : null;
     const obsBadge = matchingObs ? ` <span style="display:inline-block;padding:2px 8px;border-radius:12px;font-size:11px;font-weight:600;background:${ROLE_COLORS.observer || '#f1c40f'};color:#fff;">OBSERVER</span>` : '';
-    const hs = node.hash_size || 1;
-    const hashPrefix = node.public_key ? node.public_key.slice(0, hs * 2).toUpperCase() : '—';
+    // Unknown width is reported as unknown, not as 1 — same wording the node
+    // detail page uses (nodes.js), so the two views can't disagree.
+    const hashInfo = hashPrefixInfo(node);
+    const hashPrefixValue = hashInfo.known
+      ? `${safeEsc(hashInfo.prefix)} <span style="font-weight:400;color:var(--text-muted);">(${hashInfo.bytes}B)</span>`
+      : `<span style="font-weight:400;color:var(--text-muted);">Unknown</span>`;
     const hashPrefixRow = `<dt style="color:var(--text-muted);float:left;clear:left;width:80px;padding:2px 0;">Hash Prefix</dt>
-          <dd style="font-family:var(--mono);font-size:11px;font-weight:700;margin-left:88px;padding:2px 0;">${safeEsc(hashPrefix)} <span style="font-weight:400;color:var(--text-muted);">(${hs}B)</span></dd>`;
+          <dd style="font-family:var(--mono);font-size:11px;font-weight:700;margin-left:88px;padding:2px 0;">${hashPrefixValue}</dd>`;
     // Multi-byte support indicator for repeaters
     var mbRow = '';
     if (node.role === 'repeater' && node.multi_byte_status) {

--- a/public/map.js
+++ b/public/map.js
@@ -145,12 +145,19 @@
     // the width is unobserved the label falls back to one byte — it has to draw
     // something — but says so instead of asserting a 1-byte config.
     var hashInfo = hashPrefixInfo(node);
-    var shortHash = hashInfo.prefix;
     var unknownWidth = hashInfo.known ? '' : ' hash-unconfirmed';
     // #1356 V3: glyph is the primary non-color status carrier, hash is the data,
     // status color is a thin left-border (CSS class drives the hue).
+    //
+    // KEEP `shortHash` DIRECTLY BELOW `glyph`. test-issue-1356-map-a11y.js:133
+    // asserts the glyph-before-hash ordering with a source grep that requires
+    // `MB_GLYPHS[...]` and `shortHash` to sit within 200 characters of each
+    // other, so any statement inserted between them fails the build even though
+    // the rendering is untouched. Nothing above needs `shortHash` -- its first
+    // use is `ariaStatus`.
     var status = mbStatus || null;
     var glyph = status ? (MB_GLYPHS[status] || MB_GLYPHS.unknown) : '';
+    var shortHash = hashInfo.prefix;
     var statusClass = status ? (' ' + (MB_STATUS_CLASS[status] || MB_STATUS_CLASS.unknown)) : '';
     var ariaWidth = hashInfo.known ? '' : ', hash size unknown';
     var ariaStatus = status ? ('multi-byte ' + status + ', hash ' + shortHash + ariaWidth)

--- a/public/map.js
+++ b/public/map.js
@@ -149,12 +149,13 @@
     // #1356 V3: glyph is the primary non-color status carrier, hash is the data,
     // status color is a thin left-border (CSS class drives the hue).
     //
-    // KEEP `shortHash` DIRECTLY BELOW `glyph`. test-issue-1356-map-a11y.js:133
-    // asserts the glyph-before-hash ordering with a source grep that requires
-    // `MB_GLYPHS[...]` and `shortHash` to sit within 200 characters of each
-    // other, so any statement inserted between them fails the build even though
-    // the rendering is untouched. Nothing above needs `shortHash` -- its first
-    // use is `ariaStatus`.
+    // ORDER MATTERS: the hash variable must stay immediately below the glyph
+    // lookup. test-issue-1356-map-a11y.js:133 asserts the glyph-before-hash
+    // ordering with a source grep bounded to 200 characters, so anything
+    // inserted between the two declarations fails the build even though the
+    // rendering is untouched. Deliberately worded without naming either
+    // identifier: spelling them out here would satisfy that grep from inside
+    // this comment and the assertion could then never fail.
     var status = mbStatus || null;
     var glyph = status ? (MB_GLYPHS[status] || MB_GLYPHS.unknown) : '';
     var shortHash = hashInfo.prefix;

--- a/public/roles.js
+++ b/public/roles.js
@@ -942,6 +942,32 @@
     return abs >= 3600 ? 'critical' : abs >= 300 ? 'warning' : 'ok';
   };
 
+  /**
+   * Hash prefix for display. `hash_size` is EVIDENCE, not a default: it is set
+   * only from adverts the analyzer could actually read a size out of, so a node
+   * that has not advertised in the retention window has no value at all. Reading
+   * that absence as "1" claims a 1-byte configuration nobody observed — and the
+   * 1-byte bucket is exactly where a node is most likely to be miscounted.
+   *
+   * nodes.js (detail: "Unknown") and analytics.js ("?B") already treat it that
+   * way; this helper is the shared version so the map can too.
+   *
+   * @returns {{known: boolean, bytes: number, prefix: string}} `bytes` is the
+   * rendering width — the real evidence when known, a 1-byte fallback when not,
+   * in which case `known` is false and callers must not print it as a size.
+   */
+  window.hashPrefixInfo = function (node) {
+    var raw = node ? node.hash_size : null;
+    var known = raw != null && Number(raw) > 0;
+    var bytes = known ? Number(raw) : 1;
+    var pk = (node && node.public_key) || '';
+    return {
+      known: known,
+      bytes: bytes,
+      prefix: pk ? pk.slice(0, bytes * 2).toUpperCase() : '??',
+    };
+  };
+
   /** Render a skew sparkline SVG (inline, word-sized) */
   window.renderSkewSparkline = function(samples, w, h) {
     w = w || 120; h = h || 24;

--- a/public/style.css
+++ b/public/style.css
@@ -4706,6 +4706,14 @@ body[data-cb-preset="achromat"] {
 .mc-mb-label.status-confirmed { border-left-color: var(--mc-mb-confirmed); }
 .mc-mb-label.status-suspected { border-left-color: var(--mc-mb-suspected); }
 .mc-mb-label.status-unknown   { border-left-color: var(--mc-mb-unknown);   }
+/* The width of the prefix itself is a guess when the node has no advert-derived
+   hash_size. Dotted underline marks the digits as unverified — a shape cue, not
+   a color one, so it survives forced-colors and color-vision differences. The
+   aria-label says "hash size unknown" for AT. */
+.mc-mb-label.hash-unconfirmed span[aria-hidden="true"] {
+  text-decoration: underline dotted currentColor;
+  text-underline-offset: 2px;
+}
 
 /* Forced-colors / Windows High Contrast — degrade gracefully (audit item 7). */
 @media (forced-colors: active) {

--- a/test-frontend-helpers.js
+++ b/test-frontend-helpers.js
@@ -6864,6 +6864,78 @@ console.log('\n=== live.js: node-filter URL update preserves lat/lon/zoom (#1709
   });
 }
 
+// ===== roles.js: hashPrefixInfo =====
+// hash_size is evidence, not a default. A node the analyzer has heard no
+// countable advert from has none — rendering that as "1" invents a 1-byte
+// config. Guards the map against regressing to `node.hash_size || 1`.
+console.log('\n=== roles.js: hashPrefixInfo ===');
+{
+  const ctx = makeSandbox();
+  loadInCtx(ctx, 'public/roles.js');
+  const hashPrefixInfo = ctx.hashPrefixInfo;
+  const PK = 'aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899';
+
+  test('missing hash_size is not known', () => {
+    const r = hashPrefixInfo({ public_key: PK });
+    assert.strictEqual(r.known, false);
+  });
+
+  test('null hash_size is not known', () => {
+    assert.strictEqual(hashPrefixInfo({ public_key: PK, hash_size: null }).known, false);
+  });
+
+  test('unknown width still renders a 1-byte prefix to draw', () => {
+    const r = hashPrefixInfo({ public_key: PK, hash_size: null });
+    assert.strictEqual(r.bytes, 1);
+    assert.strictEqual(r.prefix, 'AA');
+  });
+
+  test('1-byte evidence is known', () => {
+    const r = hashPrefixInfo({ public_key: PK, hash_size: 1 });
+    assert.strictEqual(r.known, true);
+    assert.strictEqual(r.prefix, 'AA');
+  });
+
+  test('2-byte evidence widens the prefix', () => {
+    const r = hashPrefixInfo({ public_key: PK, hash_size: 2 });
+    assert.strictEqual(r.known, true);
+    assert.strictEqual(r.bytes, 2);
+    assert.strictEqual(r.prefix, 'AABB');
+  });
+
+  test('3-byte evidence widens the prefix', () => {
+    const r = hashPrefixInfo({ public_key: PK, hash_size: 3 });
+    assert.strictEqual(r.prefix, 'AABBCC');
+  });
+
+  test('hash_size 0 counts as unknown, not zero-width', () => {
+    const r = hashPrefixInfo({ public_key: PK, hash_size: 0 });
+    assert.strictEqual(r.known, false);
+    assert.strictEqual(r.prefix, 'AA');
+  });
+
+  test('missing public_key degrades to placeholder', () => {
+    assert.strictEqual(hashPrefixInfo({ hash_size: 2 }).prefix, '??');
+  });
+
+  test('null node does not throw', () => {
+    const r = hashPrefixInfo(null);
+    assert.strictEqual(r.known, false);
+    assert.strictEqual(r.prefix, '??');
+  });
+}
+
+// ===== map.js: no bare `hash_size || 1` =====
+console.log('\n=== map.js: hash size fallback ===');
+{
+  const mapSrc = fs.readFileSync(__dirname + '/public/map.js', 'utf8');
+
+  test('map.js does not default an unknown hash_size to 1', () => {
+    assert.ok(!/hash_size\s*\|\|\s*1/.test(mapSrc),
+      'map.js must go through hashPrefixInfo() — a bare `hash_size || 1` renders "unknown" as a measured 1 byte');
+  });
+}
+
 // ===== SUMMARY =====
 Promise.allSettled(pendingTests).then(() => {
   console.log(`\n${'═'.repeat(40)}`);


### PR DESCRIPTION
## The bug

`map.js` turns a missing `hash_size` into `1`:

```js
var hs = node.hash_size || 1;
```

That field is **evidence**, not a default — `computeNodeHashSizeInfo` populates it only from adverts it could read a size out of, so a node with no countable advert in the retention window has no value at all. Rendering that absence as `1` states a 1-byte configuration nobody observed, and it does so in the one place where a reader is most likely to act on it.

It is also inconsistent with the rest of the UI for the *same field on the same node*:

| view | code | renders |
|---|---|---|
| node detail | `nodes.js:683` | `Hash Prefix: **Unknown**` |
| analytics prefix table | `analytics.js:1553` | `(**?**B)` |
| map popup + label + filter | `map.js:140`, `:1588`, `:1775` | `C8 **(1B)**` |

On analyzer.meshcore.cz right now, **701 of 1007 nodes** have `hash_size: null`, so the map's 1-byte bucket is mostly nodes that were never measured. The Byte Size filter has the same problem from the other end: picking "1-byte" returns measured 1-byte nodes *and* every unheard node, which makes it hard to use for the thing it exists for.

## The fix

- `roles.js`: shared `hashPrefixInfo(node)` → `{known, bytes, prefix}`, so the map stops re-deriving the prefix in three places and the "unknown" rule lives in one.
- `map.js`:
  - **label** still draws a 1-byte prefix (it has to draw *something*) but carries `.hash-unconfirmed` and its `aria-label` says `…, hash size unknown`;
  - **popup** says `Unknown`, matching `nodes.js` wording;
  - **filter** gets its own `Unknown` bucket instead of folding unmeasured nodes into 1-byte.
- `style.css`: dotted underline for the unconfirmed prefix — a shape cue rather than a colour one, so it survives forced-colors and colour-vision differences, consistent with the #1356 approach for these labels.

`nodes.js` and `analytics.js` are left alone: they already behave correctly, and switching them to the helper would widen the diff without changing behaviour. Happy to do it in a follow-up if you'd rather have the call site count at zero.

## Tests

`node test-frontend-helpers.js` → **635 passed, 2 failed**; the two failures are `favStar`, pre-existing on master (baseline run before this change: 625 passed, 2 failed — same two).

10 new cases: `hashPrefixInfo` across missing / null / 0 / 1 / 2 / 3-byte inputs plus missing pubkey and a null node, and a guard asserting `map.js` contains no bare `hash_size || 1` so this cannot quietly come back.

## Browser validation

Headless Chromium against a live instance carrying real mesh data, same viewport (`#/map?lat=50.038502&lon=14.570556&zoom=17`), unpatched vs patched:

| | before | after |
|---|---|---|
| `aria-label` | `repeater hash C8` | `repeater hash C8, hash size unknown` |
| label class | `mc-mb-label` | `mc-mb-label hash-unconfirmed` |
| filter buttons | `all,1,2,3` | `all,1,2,3,unknown` |

The four nodes in that viewport that *do* have evidence (`157E`, `381E`, `FA74`, `C029`) render exactly as before.
