### PR TITLE
feat(map): support a CARTO basemaps API key (?key=)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -78,9 +78,10 @@
       "darkDefault": "carto-dark",
       "lightDefault": "carto-light",
       "providers": {
-        "_comment_carto": "Carto is the default free-tier provider. Optional: specify 'domain' for Carto enterprise (e.g. 'mycompany' for 'https://{s}.mycompany.cartocdn.com').",
+        "_comment_carto": "Carto is the default provider. 'token' is a CARTO basemaps API key, REQUIRED as of 2026 — without one every raster tile is served stamped 'API KEY REQUIRED' (with a 200 status, so nothing errors). Free key, no account and no card, 5M tiles/month: https://carto.com/basemaps/apikey. WARNING: the key is sent to the browser and CARTO offers no referrer restriction. Optional: specify 'domain' for Carto enterprise (e.g. 'mycompany' for 'https://{s}.mycompany.cartocdn.com').",
         "carto": {
           "enabled": true,
+          "token": "",
           "domain": ""
         },
         "_comment_osm": "OSM providers: 'mapbox', 'thunderforest', 'maptiler'. WARNING: Tokens are sent to the browser. Apply origin/referrer restrictions in your provider dashboard.",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -188,6 +188,43 @@ See `config.example.json` in the repository for all available options including:
 
 Map tile providers are enabled and configured via the `config.json` file. You can provide your custom API credentials (e.g. `osm_url`, `stamen_api_key`, `mapbox_api_key`) to activate external tile services. Once configured on the server, users can select their preferred tile provider from the Customizer UI on the client, and their choice will be persisted automatically.
 
+#### CARTO now requires an API key
+
+CARTO's raster basemaps (`carto-dark`, `carto-light`, `carto-voyager`,
+`carto-voyager-dark`, `positron-dark`) require an API key. Without one, tiles
+are still returned with a **200 status** but every one of them is stamped
+`API KEY REQUIRED` — so nothing errors, no healthcheck fires, and the map just
+quietly looks broken.
+
+Get a free key at <https://carto.com/basemaps/apikey> — no CARTO account, no
+credit card, emailed back immediately, 5 million tile requests per calendar
+month across raster and vector. Then set it as `token`:
+
+```json
+"map": {
+  "tiles": {
+    "providers": {
+      "carto": { "enabled": true, "token": "YOUR_CARTO_KEY" }
+    }
+  }
+}
+```
+
+Notes:
+
+- The query parameter is `key`. **`api_key` is silently ignored** and still
+  serves the watermarked tile.
+- The key is sent to the browser, and CARTO does not currently offer referrer
+  or origin restrictions on these keys — anyone can read it from devtools and
+  spend your quota. The 5M/month fair-use ceiling makes that low-impact for
+  most deployments, but it is worth knowing.
+- A wrong or expired key fails the same silent way as no key at all. Verify by
+  **looking at a tile**, not by checking for a 200.
+- CARTO has said it is considering freezing data updates to the raster
+  basemaps. If you would rather not depend on them, set
+  `"carto": { "enabled": false }` and use another provider — `esri` needs no
+  key at all, and `osm`/`stamen` accept their own tokens.
+
 ---
 
 ## MQTT Setup

--- a/public/customize-v2.js
+++ b/public/customize-v2.js
@@ -1835,7 +1835,9 @@
     var modalClosingLine = null;
 
     _gfModalMap = L.map(mapDiv, { zoomControl: true });
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+    L.tileLayer(window.MC_tileUrlById
+      ? window.MC_tileUrlById('carto-light', 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png')
+      : 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
       attribution: '© OpenStreetMap © CartoDB', maxZoom: 19
     }).addTo(_gfModalMap);
 
@@ -2044,7 +2046,9 @@
     if (!mapEl || typeof L === 'undefined') return;
 
     _gfMap = L.map(mapEl, { zoomControl: false, dragging: false, scrollWheelZoom: false, doubleClickZoom: false, touchZoom: false });
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+    L.tileLayer(window.MC_tileUrlById
+      ? window.MC_tileUrlById('carto-light', 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png')
+      : 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
       attribution: '© OpenStreetMap © CartoDB', maxZoom: 19
     }).addTo(_gfMap);
 

--- a/public/geofilter-builder.html
+++ b/public/geofilter-builder.html
@@ -85,13 +85,29 @@
 </div>
 
 <script src="geofilter-draft.js"></script>
+<script src="map-tile-providers.js"></script>
 <script>
 const map = L.map('map').setView([50.5, 4.4], 8);
 
-L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+const DEFAULT_DARK_TILES = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+const tiles = L.tileLayer(DEFAULT_DARK_TILES, {
   attribution: '© OpenStreetMap © CartoDB',
   maxZoom: 19
 }).addTo(map);
+
+// This page is standalone (not the SPA), so it loads the server's map config
+// itself and re-resolves the tile URL through the shared registry. Without
+// this, CARTO serves every tile stamped 'API KEY REQUIRED' — with a 200.
+fetch('/api/config/client')
+  .then(function (r) { return r.json(); })
+  .then(function (cfg) {
+    window.MC_MAP_CFG = (cfg && cfg.map) || { tiles: { providers: {} } };
+    if (typeof window.MC_initTileRegistry === 'function') window.MC_initTileRegistry();
+    if (typeof window.MC_tileUrlById === 'function') {
+      tiles.setUrl(window.MC_tileUrlById('carto-dark', DEFAULT_DARK_TILES));
+    }
+  })
+  .catch(function () { /* keep the unkeyed default */ });
 
 let points = [];
 let markers = [];

--- a/public/map-tile-providers.js
+++ b/public/map-tile-providers.js
@@ -28,6 +28,10 @@
 
   var _cfg = null;
 
+  // CARTO's raster endpoints require an API key — without one every tile comes
+  // back stamped 'API KEY REQUIRED' with a 200 status. The param is `key`;
+  // `api_key` is silently ignored and still serves the watermarked tile.
+  var _getCartoKeyParam = function() { return (_cfg && _cfg.providers && _cfg.providers.carto && _cfg.providers.carto.token) ? '?key=' + encodeURIComponent(_cfg.providers.carto.token) : ''; };
   var _getCartoBase = function() { return (_cfg && _cfg.providers && _cfg.providers.carto && _cfg.providers.carto.domain) ? 'https://{s}.' + _cfg.providers.carto.domain + '.cartocdn.com' : 'https://{s}.basemaps.cartocdn.com'; };
   var _getStamenUrl = function() { return 'https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}{r}.png' + ((_cfg && _cfg.providers && _cfg.providers.stamen && _cfg.providers.stamen.token) ? '?api_key=' + encodeURIComponent(_cfg.providers.stamen.token) : ''); };
   var _getOsmUrl = function() {
@@ -42,11 +46,11 @@
   };
 
   var BASE_STYLES = {
-    'carto-dark': { provider: 'carto', label: 'Carto Dark', url: function() { return _getCartoBase() + '/dark_all/{z}/{x}/{y}{r}.png'; }, invertFilter: null, type: 'dark', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
-    'carto-light': { provider: 'carto', label: 'Carto Positron', url: function() { return _getCartoBase() + '/light_all/{z}/{x}/{y}{r}.png'; }, invertFilter: null, type: 'light', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
-    'carto-voyager': { provider: 'carto', label: 'Carto Voyager', url: function() { return _getCartoBase() + '/rastertiles/voyager/{z}/{x}/{y}{r}.png'; }, invertFilter: null, type: 'light', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
-    'carto-voyager-dark': { provider: 'carto', label: 'Carto Voyager', url: function() { return _getCartoBase() + '/rastertiles/voyager/{z}/{x}/{y}{r}.png'; }, invertFilter: INVERT_CSS, type: 'dark', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
-    'positron-dark': { provider: 'carto', label: 'Carto Positron', url: function() { return _getCartoBase() + '/light_all/{z}/{x}/{y}{r}.png'; }, invertFilter: INVERT_CSS, type: 'dark', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
+    'carto-dark': { provider: 'carto', label: 'Carto Dark', url: function() { return _getCartoBase() + '/dark_all/{z}/{x}/{y}{r}.png' + _getCartoKeyParam(); }, invertFilter: null, type: 'dark', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
+    'carto-light': { provider: 'carto', label: 'Carto Positron', url: function() { return _getCartoBase() + '/light_all/{z}/{x}/{y}{r}.png' + _getCartoKeyParam(); }, invertFilter: null, type: 'light', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
+    'carto-voyager': { provider: 'carto', label: 'Carto Voyager', url: function() { return _getCartoBase() + '/rastertiles/voyager/{z}/{x}/{y}{r}.png' + _getCartoKeyParam(); }, invertFilter: null, type: 'light', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
+    'carto-voyager-dark': { provider: 'carto', label: 'Carto Voyager', url: function() { return _getCartoBase() + '/rastertiles/voyager/{z}/{x}/{y}{r}.png' + _getCartoKeyParam(); }, invertFilter: INVERT_CSS, type: 'dark', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
+    'positron-dark': { provider: 'carto', label: 'Carto Positron', url: function() { return _getCartoBase() + '/light_all/{z}/{x}/{y}{r}.png' + _getCartoKeyParam(); }, invertFilter: INVERT_CSS, type: 'dark', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
     'osm-standard': { provider: 'osm', label: 'OSM Standard', url: _getOsmUrl, invertFilter: null, type: 'light', attribution: '© OpenStreetMap contributors, Maps © Mapbox/Thunderforest/MapTiler', maxZoom: 18 },
     'osm-dark': { provider: 'osm', label: 'OSM Standard', url: _getOsmUrl, invertFilter: INVERT_CSS, type: 'dark', attribution: '© OpenStreetMap contributors, Maps © Mapbox/Thunderforest/MapTiler', maxZoom: 18 },
     'stamen-toner-lite': { provider: 'stamen', label: 'Stamen Toner Lite', url: _getStamenUrl, invertFilter: null, type: 'light', attribution: '© Stadia Maps © Stamen Design © OpenStreetMap', maxZoom: 20 },
@@ -183,6 +187,19 @@
   window.MC_setServerDefaultTileProvider = setServerDefault;
   window.MC_setServerDefaultLightTileProvider = setServerDefaultLight;
   window.MC_applyTileFilter             = applyTileFilter;
+
+  /**
+   * Resolve a registry id to a concrete tile-URL string, invoking function-typed
+   * `url` builders so callers never hand L.tileLayer a function (#1614). Returns
+   * `fallback` when the id isn't in the active registry (e.g. provider disabled).
+   * Lets non-map pages request a specific style without duplicating the URL.
+   */
+  window.MC_tileUrlById = function (id, fallback) {
+    var p = _hasId(id) ? REGISTRY[id] : null;
+    var u = p && (p.url || p.baseUrl);
+    if (!u) return fallback;
+    return (typeof u === 'function') ? u() : u;
+  };
 
 
   /**

--- a/public/roles.js
+++ b/public/roles.js
@@ -587,6 +587,15 @@
       if (cfg.map.tiles.lightUrl) window.TILE_LIGHT = cfg.map.tiles.lightUrl;
     }
     if (typeof window.MC_initTileRegistry === 'function') window.MC_initTileRegistry(true);
+    // CARTO raster needs an API key now, so the bare TILE_DARK/TILE_LIGHT
+    // fallbacks have to pick it up as well — getTileUrl() returns TILE_LIGHT
+    // directly in light mode and never consults the registry. Explicit
+    // darkUrl/lightUrl overrides above still win.
+    if (typeof window.MC_tileUrlById === 'function') {
+      var _tOv = (cfg.tiles || (cfg.map && cfg.map.tiles) || {});
+      if (!_tOv.dark && !_tOv.darkUrl)   window.TILE_DARK  = window.MC_tileUrlById('carto-dark',  window.TILE_DARK);
+      if (!_tOv.light && !_tOv.lightUrl) window.TILE_LIGHT = window.MC_tileUrlById('carto-light', window.TILE_LIGHT);
+    }
     if (cfg.snrThresholds) Object.assign(SNR_THRESHOLDS, cfg.snrThresholds);
     if (cfg.distThresholds) Object.assign(DIST_THRESHOLDS, cfg.distThresholds);
     if (cfg.maxHopDist != null) window.MAX_HOP_DIST = cfg.maxHopDist;

--- a/test-issue-1420-tile-providers.js
+++ b/test-issue-1420-tile-providers.js
@@ -519,6 +519,75 @@ test('MC_createLayerControl handles Auto mode and explicit layers correctly', ()
   assert.strictEqual(ev.detail.auto, true, 'event detail.auto should be true');
 });
 
+// ─── CARTO API key (?key=) ──────────────────────────────────────────────────
+
+test('Carto URLs carry no key param when no token is configured', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true } } } });
+  const url = ctx.window.MC_TILE_PROVIDERS['carto-dark'].url();
+  assert.ok(url.indexOf('?') < 0, 'should have no query string: ' + url);
+  assert.ok(/\/dark_all\/\{z\}\/\{x\}\/\{y\}\{r\}\.png$/.test(url), 'url shape preserved: ' + url);
+});
+
+test('Carto token appends ?key= (NOT ?api_key=, which CARTO ignores)', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true, token: 'abc123' } } } });
+  const url = ctx.window.MC_TILE_PROVIDERS['carto-dark'].url();
+  assert.ok(url.endsWith('?key=abc123'), 'should end with ?key=abc123: ' + url);
+  assert.ok(url.indexOf('api_key') < 0, 'must not use the api_key param: ' + url);
+});
+
+test('Carto token applies to all five carto styles', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true, token: 'k' } } } });
+  for (const id of ALL_CARTO_IDS) {
+    const url = ctx.window.MC_TILE_PROVIDERS[id].url();
+    assert.ok(url.endsWith('?key=k'), id + ' should carry the key: ' + url);
+  }
+});
+
+test('Carto token is URL-encoded', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true, token: 'a b&c=d?e' } } } });
+  const url = ctx.window.MC_TILE_PROVIDERS['carto-dark'].url();
+  assert.ok(url.endsWith('?key=' + encodeURIComponent('a b&c=d?e')), 'token must be encoded: ' + url);
+  assert.strictEqual((url.match(/\?/g) || []).length, 1, 'exactly one ? in the URL: ' + url);
+});
+
+test('Carto token composes with the enterprise domain option', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true, token: 'k', domain: 'mycompany' } } } });
+  const url = ctx.window.MC_TILE_PROVIDERS['carto-dark'].url();
+  assert.ok(url.indexOf('mycompany.cartocdn.com') >= 0, 'domain honoured: ' + url);
+  assert.ok(url.endsWith('?key=k'), 'key still appended: ' + url);
+});
+
+test('Carto token resolves lazily — set after load, picked up on re-init', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true } } } });
+  assert.ok(ctx.window.MC_TILE_PROVIDERS['carto-dark'].url().indexOf('key=') < 0, 'no key before config');
+  ctx.window.MC_MAP_CFG = { tiles: { providers: { carto: { enabled: true, token: 'late' } } } };
+  ctx.window.MC_initTileRegistry(true);
+  assert.ok(ctx.window.MC_TILE_PROVIDERS['carto-dark'].url().endsWith('?key=late'), 'key picked up after async config');
+});
+
+// ─── MC_tileUrlById ─────────────────────────────────────────────────────────
+
+test('MC_tileUrlById resolves a function-typed url to a string', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true, token: 'k' } } } });
+  const url = ctx.window.MC_tileUrlById('carto-light', 'FALLBACK');
+  assert.strictEqual(typeof url, 'string', 'must return a string, not a function');
+  assert.ok(url.endsWith('?key=k'), 'carries the key: ' + url);
+});
+
+test('MC_tileUrlById returns the fallback for a disabled or unknown provider', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: false } } } });
+  assert.strictEqual(ctx.window.MC_tileUrlById('carto-dark', 'FALLBACK'), 'FALLBACK', 'disabled provider falls back');
+  assert.strictEqual(ctx.window.MC_tileUrlById('nope', 'FALLBACK'), 'FALLBACK', 'unknown id falls back');
+});
+
 process.on('beforeExit', () => {
   console.log('');
   console.log('  ' + passed + ' passed, ' + failed + ' failed');


### PR DESCRIPTION
## Problem

CARTO's raster basemaps now require an API key. Without one, the tiles still
come back with a **200 status** — but every tile is stamped `API KEY REQUIRED`:

```
$ curl -s -o /dev/null -w '%{http_code} %{size_download}\n' \
    https://a.basemaps.cartocdn.com/dark_all/12/655/1583@2x.png
200 42612          # ← watermarked
```

Because it's a 200 and not an error, nothing catches it: no console error, no
failed request, no healthcheck. The map just quietly looks broken. This affects
all five carto styles CoreScope ships (`carto-dark`, `carto-light`,
`carto-voyager`, `carto-voyager-dark`, `positron-dark`) — including the two
CSS-inverted ones, where the watermark simply inverts to light grey and stays
perfectly legible.

Free keys are available with no CARTO account and no credit card, at 5M tile
requests/month: <https://carto.com/basemaps/apikey>

## Fix

Adds `map.tiles.providers.carto.token`, appended to the carto style URLs.

```json
"map": { "tiles": { "providers": { "carto": { "enabled": true, "token": "YOUR_KEY" } } } }
```

### ⚠️ The parameter is `key`, not `api_key`

This is the part worth flagging, because #1915 attempted this fix with
`?api_key=` and that silently does nothing — CARTO ignores the unknown
parameter and still serves the watermarked tile. Verified against the live
endpoint:

| Request | Bytes | Result |
|---|---|---|
| no key | 42612 | watermarked |
| `?api_key=<valid key>` | 42612 | **watermarked** — byte-identical to no key |
| `?key=<valid key>` | 48326 | clean |

A wrong or expired key fails the same silent way. There's a regression test
asserting `key` and asserting `api_key` never appears.

## Also covered: the call sites that bypass the registry

Setting a token only in `BASE_STYLES` isn't enough — three places request CARTO
tiles without going through the provider registry, and would have stayed
watermarked with a key configured:

- **`roles.js`** — `getTileUrl()` returns `TILE_LIGHT` directly in light mode and
  never consults the registry, so the node-detail and node-reach inset maps were
  affected. `TILE_DARK`/`TILE_LIGHT` are now re-derived from the registry once
  config loads. Explicit `darkUrl`/`lightUrl` overrides still take precedence.
- **`customize-v2.js`** — the two geofilter preview maps.
- **`geofilter-builder.html`** — standalone page (not the SPA), so it now loads
  the map config itself and re-resolves through the shared registry rather than
  duplicating URL-building logic.

## New helper

`MC_tileUrlById(id, fallback)` resolves a registry id to a concrete URL string,
invoking function-typed `url` builders (the #1614 footgun — handing
`L.tileLayer` a function makes every tile 404) and returning `fallback` when the
provider is disabled. This is what lets the three call sites above share the
registry instead of re-implementing it.

## Tests

8 new cases in `test-issue-1420-tile-providers.js`, covering: no token → no query
string; `?key=` and never `api_key`; all five styles; URL-encoding of the token;
composition with the existing `carto.domain` enterprise option; lazy resolution
when config arrives async; and both `MC_tileUrlById` paths.

```
41 passed, 0 failed
```

Also re-ran `test-issue-1614-tile-url-function.js` (3/3), `test-geofilter-draft.js`
(5/5), `test-issue-1470-node-tile-helper.js`, `test-frontend-helpers.js` and
`test-customizer-v2.js`. The latter three have pre-existing failures on `master`
(see #1858) — I confirmed the identical failure set before and after this change,
so nothing here is new.

## Notes for maintainers

- The key is sent to the browser, and CARTO does not currently offer referrer or
  origin restrictions on these keys — I verified a valid key works from any
  `Referer`, including none. The 5M/month fair-use ceiling makes that low-impact
  for most deployments, but `docs/deployment.md` now says so plainly.
- CARTO's docs state they are considering freezing data updates to the raster
  basemaps. Operators who'd rather not depend on that can set
  `"carto": { "enabled": false }` — `esri` needs no key at all. Worth a separate
  discussion about the long-term default.
- Deliberately no reformatting in this diff: 162 insertions / 9 deletions, and
  `git diff -w` is identical to `git diff`.
