### PR TITLE
fix(map): render the Esri labels overlay it was already named for

### DIFF
--- a/public/map-tile-providers.js
+++ b/public/map-tile-providers.js
@@ -51,7 +51,7 @@
     'osm-dark': { provider: 'osm', label: 'OSM Standard', url: _getOsmUrl, invertFilter: INVERT_CSS, type: 'dark', attribution: '© OpenStreetMap contributors, Maps © Mapbox/Thunderforest/MapTiler', maxZoom: 18 },
     'stamen-toner-lite': { provider: 'stamen', label: 'Stamen Toner Lite', url: _getStamenUrl, invertFilter: null, type: 'light', attribution: '© Stadia Maps © Stamen Design © OpenStreetMap', maxZoom: 20 },
     'stamen-toner-dark': { provider: 'stamen', label: 'Stamen Toner Lite', url: _getStamenUrl, invertFilter: INVERT_CSS, type: 'dark', attribution: '© Stadia Maps © Stamen Design © OpenStreetMap', maxZoom: 20 },
-    'esri-darkgray-labels': { provider: 'esri', label: 'Esri Dark Gray Canvas', url: function() { return 'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}'; }, invertFilter: null, type: 'dark', attribution: 'Tiles © Esri', maxZoom: 19 }
+    'esri-darkgray-labels': { provider: 'esri', label: 'Esri Dark Gray Canvas', url: function() { return 'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}'; }, refUrl: 'https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Reference/MapServer/tile/{z}/{y}/{x}', invertFilter: null, type: 'dark', attribution: 'Tiles © Esri', maxZoom: 19 }
   };
 
   var REGISTRY = {};
@@ -250,7 +250,17 @@
       function _makeLayer(id) {
         var p   = REGISTRY[id];
         var url = typeof p.url === 'function' ? p.url() : p.url;
-        var layer = L.tileLayer(url, { attribution: p.attribution || '', maxZoom: p.maxZoom || 19 });
+        var opts = { attribution: p.attribution || '', maxZoom: p.maxZoom || 19 };
+        var layer = L.tileLayer(url, opts);
+
+        // Two-layer providers (Esri Dark Gray Canvas) ship their place labels as
+        // a separate transparent reference tileset that has to be stacked on the
+        // base. The theme-synced path in map.js/live.js already does this; the
+        // layer control did not, so picking such a provider explicitly produced
+        // a map with no place names at all.
+        if (p.refUrl && typeof L.layerGroup === 'function') {
+          layer = L.layerGroup([layer, L.tileLayer(p.refUrl, opts)]);
+        }
         
         // Every explicit layer enforces its own filter and locks the pane
         layer.on('add', function () {

--- a/test-issue-1420-tile-providers.js
+++ b/test-issue-1420-tile-providers.js
@@ -457,6 +457,11 @@ test('MC_createLayerControl handles Auto mode and explicit layers correctly', ()
       createdLayers.push(layer);
       return layer;
     },
+    layerGroup: (layers) => {
+      const group = { _isGroup: true, _layers: layers, _events: {} };
+      group.on = (ev, cb) => { group._events[ev] = cb; };
+      return group;
+    },
     control: {
       layers: (maps) => { ctx._capturedBaseMaps = maps; return mockControl; }
     }
@@ -517,6 +522,77 @@ test('MC_createLayerControl handles Auto mode and explicit layers correctly', ()
   const ev = ctx.events[ctx.events.length - 1];
   assert.strictEqual(ev.type, 'mc-tile-provider-changed', 'event type correct');
   assert.strictEqual(ev.detail.auto, true, 'event detail.auto should be true');
+});
+
+// ─── Esri two-layer provider (base + labels reference) ──────────────────────
+
+test('Esri Dark Gray Canvas declares a labels reference layer', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, {});
+  const p = ctx.window.MC_TILE_PROVIDERS['esri-darkgray-labels'];
+  assert.ok(p, 'esri provider should be registered');
+  assert.ok(p.refUrl, 'must declare refUrl — the id promises labels');
+  assert.ok(p.refUrl.indexOf('World_Dark_Gray_Reference') >= 0, 'refUrl points at the Reference tileset: ' + p.refUrl);
+});
+
+test('Esri refUrl is a string, matching how map.js/live.js/nodes.js consume it', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, {});
+  const p = ctx.window.MC_TILE_PROVIDERS['esri-darkgray-labels'];
+  assert.strictEqual(typeof p.refUrl, 'string', 'consumers pass refUrl straight to L.tileLayer');
+  assert.ok(/\{z\}\/\{y\}\/\{x\}/.test(p.refUrl), 'Esri uses {z}/{y}/{x} order: ' + p.refUrl);
+});
+
+test('Single-layer providers declare no refUrl', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true } } } });
+  for (const id of ALL_CARTO_IDS) {
+    assert.ok(!ctx.window.MC_TILE_PROVIDERS[id].refUrl, id + ' should not declare refUrl');
+  }
+});
+
+test('Layer control stacks base + labels for a two-layer provider', () => {
+  const ctx = makeSandbox();
+  const created = [];
+  const groups  = [];
+  ctx.L = ctx.window.L = {
+    tileLayer: (url, opts) => { const l = { url, _events: {} }; l.on = (e, c) => { l._events[e] = c; }; created.push(l); return l; },
+    layerGroup: (layers) => { const g = { _isGroup: true, _layers: layers, _events: {} }; g.on = (e, c) => { g._events[e] = c; }; groups.push(g); return g; },
+    control: { layers: (maps) => { ctx._capturedBaseMaps = maps; return { addTo: function () { return this; } }; } }
+  };
+  const mockMap = {
+    hasLayer: () => false, addLayer: () => {}, removeLayer: () => {},
+    on: () => {}, off: () => {}, getPane: () => ctx.tilePane
+  };
+  loadProviders(ctx, {});
+  ctx.window.MC_initTileRegistry(false);
+  ctx.window.MC_createLayerControl(mockMap, { _isAutoGroup: true });
+
+  const entry = ctx._capturedBaseMaps['esri-darkgray-labels'];
+  assert.ok(entry, 'esri should appear in the control');
+  assert.ok(entry._isGroup, 'esri entry must be a layer group, not a bare tile layer');
+  assert.strictEqual(entry._layers.length, 2, 'group holds base + reference');
+  assert.ok(entry._layers[1].url.indexOf('World_Dark_Gray_Reference') >= 0, 'second layer is the labels overlay');
+});
+
+test('Layer control still builds a bare tile layer for single-layer providers', () => {
+  const ctx = makeSandbox();
+  ctx.L = ctx.window.L = {
+    tileLayer: (url) => { const l = { url, _events: {} }; l.on = (e, c) => { l._events[e] = c; }; return l; },
+    layerGroup: (layers) => ({ _isGroup: true, _layers: layers, on: () => {} }),
+    control: { layers: (maps) => { ctx._capturedBaseMaps = maps; return { addTo: function () { return this; } }; } }
+  };
+  const mockMap = {
+    hasLayer: () => false, addLayer: () => {}, removeLayer: () => {},
+    on: () => {}, off: () => {}, getPane: () => ctx.tilePane
+  };
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true } } } });
+  ctx.window.MC_initTileRegistry(false);
+  ctx.window.MC_createLayerControl(mockMap, { _isAutoGroup: true });
+
+  const entry = ctx._capturedBaseMaps['carto-dark'];
+  assert.ok(entry, 'carto-dark should appear in the control');
+  assert.ok(!entry._isGroup, 'single-layer provider must stay a bare tile layer');
 });
 
 process.on('beforeExit', () => {


### PR DESCRIPTION
## Problem

`esri-darkgray-labels` has never rendered any labels.

Esri serves Dark Gray Canvas as **two** tilesets that are meant to be stacked:

| Tileset | Contents |
|---|---|
| `World_Dark_Gray_Base` | land, water, roads — **no text at all** |
| `World_Dark_Gray_Reference` | place names only, transparent background |

The registry entry declares only the base. So selecting "Esri Dark Gray Canvas"
gives a grey map with coastline and roads but no place names — no *Oakland*, no
*Berkeley*, nothing. On a map whose purpose is showing where nodes are, that's
close to unusable, and it's why the option reads as broken rather than as an
alternative.

The id itself says `-labels`, and the plumbing was already there: `map.js:303`,
`live.js:1435` and `nodes.js:100` all look for `refUrl` on the provider and add
it as an overlay. The entry just never defined one.

## Fix

Two parts, because `refUrl` alone isn't enough:

1. **Declare `refUrl`** on the Esri entry, pointing at `World_Dark_Gray_Reference`.
   Kept as a plain string, matching how all three existing consumers use it
   (they pass it straight to `L.tileLayer`).

2. **Honour `refUrl` in the layer control.** `MC_createLayerControl._makeLayer`
   built a bare `L.tileLayer` per provider and ignored `refUrl` entirely — so
   even with (1), picking Esri explicitly from the control still produced an
   unlabelled map. Since the control is the main way anyone reaches this
   provider, fixing only the theme-synced path would have left the visible bug
   in place. `_makeLayer` now wraps base + reference in an `L.layerGroup` when
   `refUrl` is present; single-layer providers are untouched and still get a
   bare tile layer.

## Why this matters beyond cosmetics

This is currently the only provider in the registry that needs no API key. With
CARTO now requiring one (#1916), it's the natural fallback for operators who
don't want to depend on a keyed provider — but only if it's actually legible.

## Tests

5 new cases in `test-issue-1420-tile-providers.js`: the entry declares `refUrl`;
it points at the Reference tileset; it's a string in Esri's `{z}/{y}/{x}` order;
carto providers declare none; the control produces a 2-layer group for Esri; and
the control still produces a bare tile layer for single-layer providers. The
shared Leaflet mock gains a `layerGroup` so the control test exercises the real
path.

```
38 passed, 0 failed
```

Also re-ran `test-issue-1614-tile-url-function.js` (3/3),
`test-issue-1470-node-tile-helper.js` and `test-frontend-helpers.js` — the latter
two have pre-existing failures on `master` (#1858); I confirmed the identical
failure set before and after, so nothing here is new.

## Verification

Fetched both tilesets and composited them as the fixed control now stacks them
(z12 over the Bay, 3×3 tiles): base geometry with `San Francisco`, `Oakland`,
`Daly City`, `Emeryville`, `Golden Gate` and `San Francisco Bay` all rendering
in the expected muted grey.

Independent of #1916 — different hunks, either order merges cleanly.
