### PR TITLE
feat(map): CARTO API token — tiles.providers.carto.token rides every CARTO url

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,6 +132,7 @@ jobs:
           node test-issue-1418-deeplink-hops-channels.js
           node test-issue-1418-polish-review.js
           node test-issue-1420-tile-providers.js
+          node test-carto-api-token.js
           node test-issue-1614-tile-url-function.js
           node test-issue-1438-marker-css-vars.js
           node test-issue-1846-observers-width.js

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -186,7 +186,7 @@ See `config.example.json` in the repository for all available options including:
 
 ### Map Tile Providers
 
-Map tile providers are enabled and configured via the `config.json` file. You can provide your custom API credentials (e.g. `osm_url`, `stamen_api_key`, `mapbox_api_key`) to activate external tile services. Once configured on the server, users can select their preferred tile provider from the Customizer UI on the client, and their choice will be persisted automatically.
+Map tile providers are enabled and configured via the `config.json` file. You can provide your custom API credentials (e.g. `osm_url`, `stamen_api_key`, `mapbox_api_key`, and `tiles.providers.carto.token` for CARTO, whose raster basemaps require an API key since August 2026) to activate external tile services. Once configured on the server, users can select their preferred tile provider from the Customizer UI on the client, and their choice will be persisted automatically.
 
 ---
 

--- a/public/customize-v2.js
+++ b/public/customize-v2.js
@@ -1835,7 +1835,7 @@
     var modalClosingLine = null;
 
     _gfModalMap = L.map(mapDiv, { zoomControl: true });
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+    L.tileLayer((function(u){var c=window.MC_MAP_CFG&&window.MC_MAP_CFG.tiles;var t=c&&c.providers&&c.providers.carto&&c.providers.carto.token;return t?u+'?key='+encodeURIComponent(t):u;})('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png'), {
       attribution: '© OpenStreetMap © CartoDB', maxZoom: 19
     }).addTo(_gfModalMap);
 
@@ -2044,7 +2044,7 @@
     if (!mapEl || typeof L === 'undefined') return;
 
     _gfMap = L.map(mapEl, { zoomControl: false, dragging: false, scrollWheelZoom: false, doubleClickZoom: false, touchZoom: false });
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+    L.tileLayer((function(u){var c=window.MC_MAP_CFG&&window.MC_MAP_CFG.tiles;var t=c&&c.providers&&c.providers.carto&&c.providers.carto.token;return t?u+'?key='+encodeURIComponent(t):u;})('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png'), {
       attribution: '© OpenStreetMap © CartoDB', maxZoom: 19
     }).addTo(_gfMap);
 

--- a/public/map-tile-providers.js
+++ b/public/map-tile-providers.js
@@ -29,6 +29,14 @@
   var _cfg = null;
 
   var _getCartoBase = function() { return (_cfg && _cfg.providers && _cfg.providers.carto && _cfg.providers.carto.domain) ? 'https://{s}.' + _cfg.providers.carto.domain + '.cartocdn.com' : 'https://{s}.basemaps.cartocdn.com'; };
+  // CARTO's raster basemaps require an API key since Aug 2026 - anonymous
+  // requests get an "API KEY REQUIRED" watermark on every tile. The token
+  // rides only CARTO urls, mirroring how stamen/osm tokens already work.
+  var _cartoUrl = function(path) {
+    var u = _getCartoBase() + path;
+    var t = (_cfg && _cfg.providers && _cfg.providers.carto && _cfg.providers.carto.token) ? String(_cfg.providers.carto.token) : '';
+    return t ? u + (u.indexOf('?') >= 0 ? '&' : '?') + 'key=' + encodeURIComponent(t) : u;
+  };
   var _getStamenUrl = function() { return 'https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}{r}.png' + ((_cfg && _cfg.providers && _cfg.providers.stamen && _cfg.providers.stamen.token) ? '?api_key=' + encodeURIComponent(_cfg.providers.stamen.token) : ''); };
   var _getOsmUrl = function() {
     if (_cfg && _cfg.providers && _cfg.providers.osm && _cfg.providers.osm.provider && _cfg.providers.osm.token) {
@@ -42,11 +50,11 @@
   };
 
   var BASE_STYLES = {
-    'carto-dark': { provider: 'carto', label: 'Carto Dark', url: function() { return _getCartoBase() + '/dark_all/{z}/{x}/{y}{r}.png'; }, invertFilter: null, type: 'dark', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
-    'carto-light': { provider: 'carto', label: 'Carto Positron', url: function() { return _getCartoBase() + '/light_all/{z}/{x}/{y}{r}.png'; }, invertFilter: null, type: 'light', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
-    'carto-voyager': { provider: 'carto', label: 'Carto Voyager', url: function() { return _getCartoBase() + '/rastertiles/voyager/{z}/{x}/{y}{r}.png'; }, invertFilter: null, type: 'light', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
-    'carto-voyager-dark': { provider: 'carto', label: 'Carto Voyager', url: function() { return _getCartoBase() + '/rastertiles/voyager/{z}/{x}/{y}{r}.png'; }, invertFilter: INVERT_CSS, type: 'dark', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
-    'positron-dark': { provider: 'carto', label: 'Carto Positron', url: function() { return _getCartoBase() + '/light_all/{z}/{x}/{y}{r}.png'; }, invertFilter: INVERT_CSS, type: 'dark', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
+    'carto-dark': { provider: 'carto', label: 'Carto Dark', url: function() { return _cartoUrl('/dark_all/{z}/{x}/{y}{r}.png'); }, invertFilter: null, type: 'dark', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
+    'carto-light': { provider: 'carto', label: 'Carto Positron', url: function() { return _cartoUrl('/light_all/{z}/{x}/{y}{r}.png'); }, invertFilter: null, type: 'light', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
+    'carto-voyager': { provider: 'carto', label: 'Carto Voyager', url: function() { return _cartoUrl('/rastertiles/voyager/{z}/{x}/{y}{r}.png'); }, invertFilter: null, type: 'light', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
+    'carto-voyager-dark': { provider: 'carto', label: 'Carto Voyager', url: function() { return _cartoUrl('/rastertiles/voyager/{z}/{x}/{y}{r}.png'); }, invertFilter: INVERT_CSS, type: 'dark', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
+    'positron-dark': { provider: 'carto', label: 'Carto Positron', url: function() { return _cartoUrl('/light_all/{z}/{x}/{y}{r}.png'); }, invertFilter: INVERT_CSS, type: 'dark', attribution: '© OpenStreetMap © CartoDB', maxZoom: 19 },
     'osm-standard': { provider: 'osm', label: 'OSM Standard', url: _getOsmUrl, invertFilter: null, type: 'light', attribution: '© OpenStreetMap contributors, Maps © Mapbox/Thunderforest/MapTiler', maxZoom: 18 },
     'osm-dark': { provider: 'osm', label: 'OSM Standard', url: _getOsmUrl, invertFilter: INVERT_CSS, type: 'dark', attribution: '© OpenStreetMap contributors, Maps © Mapbox/Thunderforest/MapTiler', maxZoom: 18 },
     'stamen-toner-lite': { provider: 'stamen', label: 'Stamen Toner Lite', url: _getStamenUrl, invertFilter: null, type: 'light', attribution: '© Stadia Maps © Stamen Design © OpenStreetMap', maxZoom: 20 },

--- a/test-carto-api-token.js
+++ b/test-carto-api-token.js
@@ -1,0 +1,125 @@
+/* test-carto-api-token.js — CARTO API token support in the tile registry.
+ *
+ * CARTO's raster basemaps require an API key since August 2026: anonymous
+ * requests get an "API KEY REQUIRED" watermark on every tile. Config gains
+ * tiles.providers.carto.token, mirroring the stamen/osm token knobs that
+ * already exist.
+ *
+ * Contract under test:
+ *   - With providers.carto.token set, every carto-provider url carries
+ *     ?key=<token>, URL-encoded.
+ *   - Without a token, urls are byte-identical to the historical anonymous
+ *     form (no dangling '?').
+ *   - The token never leaks onto a non-CARTO provider's url.
+ *
+ * Runs via: node test-carto-api-token.js
+ * No jsdom or Playwright dependency — pure vm sandbox.
+ */
+'use strict';
+const vm   = require('vm');
+const fs   = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); passed++; console.log('  ✅ ' + name); }
+  catch (e) { failed++; console.log('  ❌ ' + name + ': ' + e.message); }
+}
+
+function makeStorage() {
+  const store = {};
+  return {
+    getItem(k)    { return Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null; },
+    setItem(k, v) { store[k] = String(v); },
+    removeItem(k) { delete store[k]; },
+    clear()       { for (const k of Object.keys(store)) delete store[k]; },
+  };
+}
+
+function makeSandbox() {
+  const tilePane = { style: { filter: '' }, setAttribute() {}, getAttribute() { return null; }, removeAttribute() {} };
+  const ctx = {
+    console, setTimeout, clearTimeout,
+    JSON, Date, Math, Object, Array, String, Number, Boolean,
+    localStorage: makeStorage(),
+    document: {
+      documentElement: { getAttribute: () => 'dark' },
+      querySelector: (sel) => sel === '.leaflet-tile-pane' ? tilePane : null,
+      querySelectorAll: () => [],
+      addEventListener: () => {},
+    },
+    window: {
+      addEventListener: () => {},
+      dispatchEvent: () => true,
+      matchMedia: () => ({ matches: false, addEventListener: () => {} }),
+    },
+    CustomEvent: function (type, init) { this.type = type; this.detail = (init && init.detail) || null; }
+  };
+  ctx.window.localStorage = ctx.localStorage;
+  ctx.globalThis = ctx;
+  vm.createContext(ctx);
+  ctx.window.document = ctx.document;
+  return ctx;
+}
+
+function loadProviders(ctx, mapCfg) {
+  if (mapCfg !== undefined) ctx.window.MC_MAP_CFG = mapCfg;
+  const src = fs.readFileSync(path.join(__dirname, 'public', 'map-tile-providers.js'), 'utf8');
+  vm.runInContext(src, ctx);
+}
+
+const CARTO_IDS = ['carto-dark', 'carto-light', 'carto-voyager', 'carto-voyager-dark', 'positron-dark'];
+
+console.log('── CARTO API token ──');
+
+test('carto token rides every carto url as ?key=', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true, token: 'tok123' } } } });
+  ctx.window.MC_initTileRegistry(false);
+  const reg = ctx.window.MC_TILE_PROVIDERS;
+  for (const id of CARTO_IDS) {
+    const url = reg[id].url();
+    assert.ok(url.indexOf('?key=tok123') >= 0, id + ' must carry the key, got ' + url);
+    assert.ok(url.indexOf('{z}') >= 0, id + ' keeps its template');
+  }
+});
+
+test('no token: urls stay byte-identical to the anonymous form', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true } } } });
+  ctx.window.MC_initTileRegistry(false);
+  const url = ctx.window.MC_TILE_PROVIDERS['carto-dark'].url();
+  assert.strictEqual(url, 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png');
+});
+
+test('token is URL-encoded', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true, token: 'a b&c' } } } });
+  ctx.window.MC_initTileRegistry(false);
+  assert.ok(ctx.window.MC_TILE_PROVIDERS['carto-dark'].url().indexOf('?key=a%20b%26c') >= 0);
+});
+
+test('token never leaks onto a non-CARTO provider', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true, token: 'tok123' }, osm: { enabled: true }, stamen: { enabled: true, token: 'stok' } } } });
+  ctx.window.MC_initTileRegistry(false);
+  const reg = ctx.window.MC_TILE_PROVIDERS;
+  for (const id of Object.keys(reg)) {
+    if (CARTO_IDS.indexOf(id) >= 0) continue;
+    const url = typeof reg[id].url === 'function' ? reg[id].url() : reg[id].url;
+    assert.ok(url.indexOf('tok123') < 0, id + ' must not carry the carto token: ' + url);
+  }
+});
+
+test('carto domain override and token compose', () => {
+  const ctx = makeSandbox();
+  loadProviders(ctx, { tiles: { providers: { carto: { enabled: true, domain: 'example', token: 'tok' } } } });
+  ctx.window.MC_initTileRegistry(false);
+  const url = ctx.window.MC_TILE_PROVIDERS['carto-dark'].url();
+  assert.ok(url.indexOf('https://{s}.example.cartocdn.com/') === 0, url);
+  assert.ok(url.indexOf('?key=tok') >= 0, url);
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
CARTO's raster basemaps require an API key since August 2026 — anonymous requests now get an **API KEY REQUIRED** watermark on every tile, which is what a deployment's dark map shows today.

This adds `tiles.providers.carto.token` to the map config, mirroring the `stamen`/`osm` token knobs that already exist:

```json
{ "map": { "tiles": { "providers": { "carto": { "token": "your-carto-key" } } } } }
```

- the token is URL-encoded and rides **only** CARTO urls (all five registry styles, plus the customizer's two `light_all` previews)
- no token: every url stays byte-identical to the anonymous form
- composes with the existing `carto.domain` override
- regression-tested in `test-carto-api-token.js` (same vm-sandbox harness as `test-issue-1420`), wired into deploy.yml
- keys are free at <https://carto.com/basemaps/apikey> (5M tiles/month)

Running in production on ScotMesh's instance (config + the two files) since today; this PR is the upstream form so image updates keep it.