### PR TITLE
fix: unbreak master — decouple the pathTrust builder test from the default

### DIFF
--- a/cmd/ingestor/neighbor_builder_test.go
+++ b/cmd/ingestor/neighbor_builder_test.go
@@ -286,8 +286,12 @@ func TestNeighborEdgesBuilderPathTrustExcludesOneByte(t *testing.T) {
 	defer store.Close()
 	seedTrustFixture(t, store, "bb")
 
-	// nil == package default (MinHashBytesForMapping = 2).
-	if _, err := store.buildAndPersistNeighborEdges(nil); err != nil {
+	// Pass the threshold explicitly rather than leaning on the package default.
+	// This test is about what happens AT threshold 2, not about what the default
+	// happens to be, and coupling the two made it fail the moment the default
+	// moved to 1 (#1929).
+	trust := &packetpath.TrustConfig{MinHashBytesForMapping: 2}
+	if _, err := store.buildAndPersistNeighborEdges(trust); err != nil {
 		t.Fatalf("buildAndPersistNeighborEdges: %v", err)
 	}
 


### PR DESCRIPTION
**master is currently red.** This is the fix.

```
--- FAIL: TestNeighborEdgesBuilderPathTrustExcludesOneByte
    neighbor_builder_test.go:301: 1-byte hop must not produce an edge under
    the default threshold, got 1
```

## What happened

Two PRs that were each green on their own:

- **#1929** moved `DefaultMinHashBytesForMapping` from 2 to 1.
- **#1930** carries `TestNeighborEdgesBuilderPathTrustExcludesOneByte`, written when the default was 2.

Neither pipeline saw the other, because a `pull_request` run tests the merge commit as it stood when that run started. Both merged, and the combination fails. My mistake for merging them in the same batch without re-running one against the other.

## The fix

The test passed `nil` for the trust config and leaned on the package default being 2:

```go
// nil == package default (MinHashBytesForMapping = 2).
store.buildAndPersistNeighborEdges(nil)
```

That coupling is the real defect. The test is about what happens **at threshold 2**, not about what the default happens to be. It now says so:

```go
trust := &packetpath.TrustConfig{MinHashBytesForMapping: 2}
store.buildAndPersistNeighborEdges(trust)
```

It keeps testing exactly what it was written to test, and stops breaking when the default moves. The sibling `TestNeighborEdgesBuilderPathTrustAllowsTwoByte` already passes its own fixture explicitly, so this brings the two into line.

**No production code changed.** `cmd/ingestor` PathTrust and Neighbor tests pass.

## Worth recording

This is the failure mode I have been flagging on other PRs all day, and I walked into it myself: green CI on a PR is a statement about the base it was tested against, not about master. Two PRs can each be green and still be red together. Nothing about the review process would have caught it — only re-running one against the other, or a merge queue, would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wzwr3eXseyNM7Xj598djjE
