### PR TITLE
test(#1356): assert the rendered label, not where identifiers sit in map.js

### DIFF
--- a/public/map.js
+++ b/public/map.js
@@ -2392,6 +2392,12 @@
   }
 
   if (typeof window !== 'undefined') {
-    window.__meshcoreMapInternals = { createClusterGroup: createClusterGroup, makeClusterIcon: makeClusterIcon };
+    window.__meshcoreMapInternals = {
+      createClusterGroup: createClusterGroup,
+      makeClusterIcon: makeClusterIcon,
+      // #1356: exposed so the a11y test can assert what the label RENDERS
+      // instead of grepping map.js for where two identifiers sit.
+      makeRepeaterLabelIcon: makeRepeaterLabelIcon,
+    };
   }
 })();

--- a/test-issue-1356-map-a11y.js
+++ b/test-issue-1356-map-a11y.js
@@ -27,6 +27,79 @@ function assert(cond, msg) {
 const mapSrc   = fs.readFileSync(path.join(__dirname, 'public', 'map.js'),   'utf8');
 const cssSrc   = fs.readFileSync(path.join(__dirname, 'public', 'style.css'), 'utf8');
 
+// ── Load map.js in a DOM-less sandbox so the label assertions can call the
+// real makeRepeaterLabelIcon and look at what it renders.
+//
+// The V3 label checks used to be source greps. One of them bounded the distance
+// between two identifiers in map.js to 200 characters, which made it fail on any
+// statement inserted between them even when the rendering was unchanged -- and,
+// worse, let a comment that happened to mention both identifiers satisfy it, so
+// it could report green while the ordering was in fact wrong. A grep cannot tell
+// code from prose about code.
+//
+// Same sandbox shape as test-map-clustering.js; no browser, so this still runs
+// in the JS-unit-tests CI step.
+function makeLeafletShim() {
+  const chain = () => { const o = { addTo: () => o, on: () => o, setStyle: () => o, remove: () => o,
+                                    bindTooltip: () => o, setLatLng: () => o, extend: () => o }; return o; };
+  const control = () => chain();
+  control.layers = () => chain();
+  return {
+    divIcon: (opts) => opts,               // the icon under test: keep the options verbatim
+    point: (x, y) => ({ x: x, y: y }),
+    circleMarker: chain, polyline: chain, polygon: chain, marker: chain,
+    tileLayer: chain, layerGroup: chain, featureGroup: chain, control: control,
+    latLngBounds: chain, latLng: (a, b) => ({ lat: a, lng: b }),
+    map: () => Object.assign(chain(), { setView: () => chain(), getZoom: () => 11,
+      getCenter: () => ({ lat: 0, lng: 0 }), getBounds: () => ({ contains: () => true }),
+      fitBounds: () => chain(), invalidateSize: () => {}, hasLayer: () => false,
+      addLayer: () => chain(), removeLayer: () => {} }),
+    markerClusterGroup: chain, MarkerClusterGroup: function () {},
+    DomUtil: { create: () => ({}) }, Icon: { Default: { prototype: {} } },
+  };
+}
+
+function loadMapInternals() {
+  const vm = require('vm');
+  const ctx = {
+    window: {},
+    document: {
+      addEventListener() {}, getElementById() { return null; },
+      querySelector() { return null; }, querySelectorAll() { return []; },
+      createElement() { return { id: '', textContent: '', innerHTML: '', style: {}, dataset: {},
+        appendChild() {}, addEventListener() {}, setAttribute() {},
+        classList: { add() {}, remove() {}, toggle() {} } }; },
+      head: { appendChild() {} }, body: { appendChild() {} },
+      documentElement: { getAttribute: () => null, dataset: {} },
+    },
+    console, Date, Math, Array, Object, String, Number, JSON, RegExp, Error, TypeError,
+    parseInt, parseFloat, isFinite, isNaN, Map, Set, Promise, URLSearchParams,
+    setTimeout: () => 0, clearTimeout() {}, setInterval: () => 0, clearInterval() {},
+    registerPage: () => {}, esc: (x) => x, onWS: () => {}, offWS: () => {},
+    localStorage: (() => { const st = {}; return { getItem: k => (k in st ? st[k] : null),
+      setItem: (k, v) => { st[k] = String(v); }, removeItem: k => { delete st[k]; } }; })(),
+    fetch: () => Promise.resolve({ json: () => Promise.resolve({}) }),
+    addEventListener() {}, dispatchEvent() {},
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+    matchMedia: () => ({ matches: false, addEventListener() {} }),
+    navigator: {}, location: { hash: '', protocol: 'https:', host: 'localhost' },
+    L: makeLeafletShim(),
+  };
+  ctx.window.L = ctx.L;
+  vm.createContext(ctx);
+  for (const f of ['public/roles.js', 'public/map.js']) {
+    vm.runInContext(fs.readFileSync(path.join(__dirname, f), 'utf8'), ctx, { filename: f });
+    for (const k of Object.keys(ctx.window)) ctx[k] = ctx.window[k];
+  }
+  return ctx.window.__meshcoreMapInternals;
+}
+
+// Deliberately NOT wrapped in try/catch that warns and continues: a sandbox that
+// fails to load must fail the suite, not quietly drop every assertion below it.
+const mapInternals = loadMapInternals();
+const NODE = { public_key: '3e7a1b9c'.repeat(8), hash_size: 2 };
+const THIN = '\u2009';
+
 console.log('\n=== #1356 V1: cluster bubble — neutral fill, border-style ramp, ARIA ===');
 
 // V1.a — CSS must define a neutral cluster fill constant (not the bucket color).
@@ -129,19 +202,34 @@ assert(/--mc-mb-unknown\s*:\s*#FF8888/i.test(cssSrc),
 assert(/border-left\s*:\s*3px solid/.test(cssSrc),
   '.mc-mb-label has 3px solid border-left (colored accent stripe)');
 
-// V3.e — makeRepeaterLabelIcon prepends MB_GLYPHS[status].
-assert(/MB_GLYPHS\[[^\]]+\][\s\S]{0,200}shortHash|shortHash[\s\S]{0,200}MB_GLYPHS\[/.test(mapSrc),
-  'makeRepeaterLabelIcon prepends MB_GLYPHS glyph to the hash text');
+// V3.e/f/g are asserted on what makeRepeaterLabelIcon RENDERS, not on where its
+// identifiers sit in the source. See loadMapInternals() above for why.
+assert(mapInternals && typeof mapInternals.makeRepeaterLabelIcon === 'function',
+  'map.js exposes makeRepeaterLabelIcon on window.__meshcoreMapInternals');
 
-// V3.f — aria-label "multi-byte <status>, hash <ID>".
-assert(/aria-label="'\s*\+\s*ariaStatus\s*\+\s*'"/.test(mapSrc) ||
-       /'multi-byte '\s*\+\s*status\s*\+\s*', hash '\s*\+\s*shortHash/.test(mapSrc) ||
-       /aria-label="multi-byte \$\{[^}]+\}, hash \$\{shortHash\}"/.test(mapSrc),
+const labelConfirmed = mapInternals.makeRepeaterLabelIcon(NODE, false, false, 'confirmed').html;
+const labelUnknown   = mapInternals.makeRepeaterLabelIcon(NODE, false, false, 'unknown').html;
+const labelNoStatus  = mapInternals.makeRepeaterLabelIcon(NODE, false, false, null).html;
+
+// V3.e — the glyph is PREPENDED to the hash: glyph, thin space, hash, in that
+// order and with nothing between them.
+assert(labelConfirmed.includes('>\u2713' + THIN + '3E7A<'),
+  'makeRepeaterLabelIcon prepends the confirmed glyph to the hash text');
+assert(labelUnknown.includes('>\u2717' + THIN + '3E7A<'),
+  'makeRepeaterLabelIcon prepends the unknown glyph to the hash text');
+assert(labelNoStatus.includes('>3E7A<') && !labelNoStatus.includes(THIN),
+  'with no multi-byte status the label is the bare hash, no glyph and no thin space');
+
+// V3.f — aria-label "multi-byte <status>, hash <ID>", and the plain form without.
+assert(labelConfirmed.includes('aria-label="multi-byte confirmed, hash 3E7A"'),
   'makeRepeaterLabelIcon emits aria-label "multi-byte <status>, hash <ID>"');
+assert(labelNoStatus.includes('aria-label="repeater hash 3E7A"'),
+  'without a status the aria-label is "repeater hash <ID>"');
 
-// V3.g — Glyph span must be aria-hidden so AT does not read "check mark 3 E".
-assert(/<span aria-hidden="true">[\s\S]{0,100}shortHash|<span aria-hidden="true">'\s*\+\s*(?:glyph|visible)/.test(mapSrc) ||
-       /aria-hidden="true">'\s*\+\s*visible/.test(mapSrc),
+// V3.g — the visible glyph+hash span is aria-hidden so AT reads the label only
+// (not "check mark 3 E"). Asserted on the emitted markup: the glyph must sit
+// inside a span carrying aria-hidden.
+assert(/<span aria-hidden="true">\u2713\u20093E7A<\/span>/.test(labelConfirmed),
   'visible glyph+hash span is aria-hidden="true" (AT reads aria-label only)');
 
 // V3.h — repeater label MUST use the neutral fill via var(--mc-mb-fill); MUST


### PR DESCRIPTION
Follow-up to the review on #1912, where this assertion cost a round trip. Independent of that PR — this branch is off current `master` and touches no code path it changes.

## The problem

`#1356 V3.e`, `V3.f` and `V3.g` all describe what `makeRepeaterLabelIcon` **produces**, but all three assert it by grepping `public/map.js`. V3.e also bounds the distance between two identifiers:

```js
assert(/MB_GLYPHS\[[^\]]+\][\s\S]{0,200}shortHash|shortHash[\s\S]{0,200}MB_GLYPHS\[/.test(mapSrc),
  'makeRepeaterLabelIcon prepends MB_GLYPHS glyph to the hash text');
```

Three separate failure modes, all observed:

**1. It fails on edits that change nothing.** #1912 inserts one variable declaration in that function; the markup is byte-identical and the build went red.

**2. It cannot tell code from prose about code.** My first attempt at fixing #1912 added a comment explaining the constraint — and the comment mentioned both identifiers, so it satisfied the grep by itself. With that comment present I moved the hash assignment away from the glyph, reintroducing the exact defect, and the test still reported green. A check that a comment can satisfy is worse than one that is merely brittle.

**3. It does not assert the thing it is named after.** On `master` the match is not the declaration order at all. It is `MB_GLYPHS[...]` reaching the *later* `shortHash` inside `ariaStatus`, 212 characters downstream. Whether the glyph is actually prepended to the hash is incidental to whether this passes.

That third point also corrects something I said on #1912, and it corrects it against myself: both the 312 you quoted and the 299 I "corrected" it to are the distance between the two **declarations**, which is not the distance the regex uses. Measuring the one it does use:

| tree | `MB_GLYPHS[` → next `shortHash` | assertion |
|---|---|---|
| `master` | 212 | pass |
| #1912 before the fix | 277 | fail |
| moving `unknownWidth` below the glyph | **343** | fail |
| moving `shortHash` below the glyph | 54 | pass |

So moving `unknownWidth` down does not merely fall short — it makes the gap *worse*, because it lands between the glyph and `ariaStatus`. My earlier "233, still 33 over" was the wrong metric on the wrong pair. Apologies; the conclusion happened to hold but the reasoning did not.

## What this does

Loads `map.js` in the same DOM-less `vm` sandbox `test-map-clustering.js` already uses, exposes `makeRepeaterLabelIcon` through the existing `window.__meshcoreMapInternals` hook, and asserts the emitted markup:

- glyph, `U+2009` thin space, hash — in that order and adjacent;
- no glyph and no thin space when there is no multi-byte status;
- `aria-label` exactly `multi-byte <status>, hash <ID>`, and `repeater hash <ID>` without one;
- the visible span carries `aria-hidden`.

No browser, so it stays in the JS-unit-tests step rather than moving to Playwright.

## Mutation-tested, not eyeballed

| mutation | old V3.e/f/g | new |
|---|---|---|
| glyph moved after the hash | **all silent** | caught |
| plain space instead of `U+2009` | **all silent** | caught |
| span loses `aria-hidden` | V3.g caught | caught |
| `aria-label` loses its comma | **all silent** | caught |
| 200 chars inserted between the identifiers (no behaviour change) | V3.e **fails** | passes |

Full JS unit list from `.github/workflows/deploy.yml`: 65/65.

## Notes for review

- V3.a–V3.d (MB_GLYPHS definitions, CSS variables, the border rule) are left as source/CSS greps. The glyph values are now covered implicitly by the rendered-output assertions, but converting the CSS ones needs a different approach and did not belong here.
- The sandbox loader has no `try`/`catch` that warns and continues. If `map.js` stops loading, the suite must fail rather than silently skip every assertion below it.
- If this lands, the ordering comment in #1912 becomes obsolete and I will drop it there. I deliberately did not touch it from this branch so the two do not conflict textually.
