### PR TITLE
test(#1616): wait for swatch focus to move instead of reading it immediately

### DIFF
--- a/test-channel-color-picker-e2e.js
+++ b/test-channel-color-picker-e2e.js
@@ -145,6 +145,24 @@ function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
     const firstColor = await page.evaluate(() =>
       document.activeElement.getAttribute('data-color'));
     await page.keyboard.press('ArrowRight');
+    // Wait for focus to actually move rather than reading activeElement on the
+    // next tick. The keydown handler moves focus, but under CI load that can
+    // land after Playwright's evaluate has already run, and the assertion then
+    // compares the swatch against itself: "was #ef4444, now #ef4444".
+    //
+    // This is the same macrotask race the "outside click" step below documents
+    // at length for #1317; the fix there was to wait on the real condition
+    // instead of a proxy, and this step needs it too. Observed failing on the
+    // master pushes for 589fa987 (2026-08-31) and 859173f1 (2026-09-02), and
+    // on PR #1884, which passed unchanged on a re-run.
+    try {
+      await page.waitForFunction((prev) => {
+        const el = document.activeElement;
+        if (!el || !el.classList || !el.classList.contains('cc-swatch')) return false;
+        const c = el.getAttribute('data-color');
+        return !!c && c !== prev;
+      }, firstColor, { timeout: 3000 });
+    } catch (_) { /* fall through so the assertion reports the actual value */ }
     const nextColor = await page.evaluate(() =>
       document.activeElement.getAttribute('data-color'));
     assert(nextColor && nextColor !== firstColor,

--- a/test-live-multibyte-only-e2e.js
+++ b/test-live-multibyte-only-e2e.js
@@ -119,8 +119,24 @@ function makePkt(hash, rawHex) {
       localStorage.setItem('live-multibyte-only', 'true');
     });
     await persistPage.goto(BASE + '/#/live', { waitUntil: 'domcontentloaded' });
-    await persistPage.waitForFunction(() => !!document.getElementById('liveMultibyteToggle'), { timeout: 15000 });
-    const checked = await persistPage.evaluate(() => document.getElementById('liveMultibyteToggle').checked);
+    // Wait for the toggle to be RESTORED, not merely present. The element
+    // existing does not mean the code that reads localStorage and sets
+    // .checked has run yet, and under CI load it frequently has not. Waiting
+    // on existence is a proxy for the thing under test, which is the same
+    // mistake #1317 documented in test-channel-color-picker-e2e.js.
+    //
+    // Observed failing on the master push for 859173f1 (2026-09-02, re-run)
+    // with none of the PR code that first surfaced it (#1933) present.
+    try {
+      await persistPage.waitForFunction(() => {
+        const el = document.getElementById('liveMultibyteToggle');
+        return !!el && el.checked === true;
+      }, { timeout: 15000 });
+    } catch (_) { /* fall through so the assertion reports what it actually saw */ }
+    const checked = await persistPage.evaluate(() => {
+      const el = document.getElementById('liveMultibyteToggle');
+      return el ? el.checked : '(toggle absent)';
+    });
     await persistCtx.close();
     assert(checked === true, 'multibyte toggle should restore checked=true from localStorage');
   });

--- a/test-live-multibyte-only-e2e.js
+++ b/test-live-multibyte-only-e2e.js
@@ -119,24 +119,8 @@ function makePkt(hash, rawHex) {
       localStorage.setItem('live-multibyte-only', 'true');
     });
     await persistPage.goto(BASE + '/#/live', { waitUntil: 'domcontentloaded' });
-    // Wait for the toggle to be RESTORED, not merely present. The element
-    // existing does not mean the code that reads localStorage and sets
-    // .checked has run yet, and under CI load it frequently has not. Waiting
-    // on existence is a proxy for the thing under test, which is the same
-    // mistake #1317 documented in test-channel-color-picker-e2e.js.
-    //
-    // Observed failing on the master push for 859173f1 (2026-09-02, re-run)
-    // with none of the PR code that first surfaced it (#1933) present.
-    try {
-      await persistPage.waitForFunction(() => {
-        const el = document.getElementById('liveMultibyteToggle');
-        return !!el && el.checked === true;
-      }, { timeout: 15000 });
-    } catch (_) { /* fall through so the assertion reports what it actually saw */ }
-    const checked = await persistPage.evaluate(() => {
-      const el = document.getElementById('liveMultibyteToggle');
-      return el ? el.checked : '(toggle absent)';
-    });
+    await persistPage.waitForFunction(() => !!document.getElementById('liveMultibyteToggle'), { timeout: 15000 });
+    const checked = await persistPage.evaluate(() => document.getElementById('liveMultibyteToggle').checked);
     await persistCtx.close();
     assert(checked === true, 'multibyte toggle should restore checked=true from localStorage');
   });


### PR DESCRIPTION
This is the test that has been keeping master red on both sides of today's queue run.

## The failure

```
✗ ArrowRight cycles focus across swatches:
  ArrowRight should move focus to next swatch (was #ef4444, now #ef4444)
```

Observed on:

| where | when |
|---|---|
| master push `589fa987` | 2026-08-31 — the last completed master run before today |
| master push `859173f1` | 2026-09-02 — the first completed master run after #1938 |
| PR #1884 | 2026-09-02, passed unchanged on a re-run |

**Two out of two completed master runs.** Master has produced exactly two finished pipelines since 2026-08-31 and this test failed both, which is why the branch has had no green badge either side of a day of merges.

## The cause

```js
await page.keyboard.press('ArrowRight');
const nextColor = await page.evaluate(() =>
  document.activeElement.getAttribute('data-color'));
```

It reads `document.activeElement` on the tick after the key press. The keydown handler moves focus, but under CI load that can land after the evaluate has already run, so the assertion compares the swatch against itself and reports the same colour twice.

**This file already knows about this.** The "outside click" step below carries a long comment about exactly this macrotask race for #1317, and the conclusion there was to wait on the real condition instead of a proxy. That step got the treatment and this one did not.

## The fix

Wait for `activeElement` to be a `.cc-swatch` whose `data-color` differs from the one focused before the key press, with a 3s budget. The wait is wrapped so that a timeout falls through to the original assertion, which then reports the value actually observed rather than a bare Playwright timeout — a failing test should still say what it saw.

**No product code changed.** One file, +18 lines, all of it the wait and the reasoning.

## What this does not claim

It does not prove the focus handler is correct, only that the test stops racing it. If ArrowRight is ever genuinely broken, this still fails, and now with a useful message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wzwr3eXseyNM7Xj598djjE
