### PR TITLE
build: upgrade Go toolchain to 1.27

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,10 +41,10 @@ jobs:
       - name: Clean Go module cache
         run: rm -rf ~/go/pkg/mod 2>/dev/null || true
 
-      - name: Set up Go 1.22
+      - name: Set up Go 1.27
         uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version: '1.27'
           cache-dependency-path: |
             cmd/server/go.sum
             cmd/ingestor/go.sum
@@ -261,10 +261,10 @@ jobs:
       - name: Clean Go module cache
         run: rm -rf ~/go/pkg/mod 2>/dev/null || true
 
-      - name: Set up Go 1.22
+      - name: Set up Go 1.27
         uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version: '1.27'
           cache-dependency-path: cmd/server/go.sum
 
       - name: Build Go server
@@ -663,10 +663,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up Go 1.22
+      - name: Set up Go 1.27
         uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version: '1.27'
 
       - name: Build corescope-decrypt (static, linux/amd64)
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # BUILDPLATFORM is auto-set by buildx; default to linux/amd64 so plain
 # `docker build` (without buildx) doesn't fail on an empty platform string.
 ARG BUILDPLATFORM=linux/amd64
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine AS builder
 
 ARG APP_VERSION=unknown
 ARG GIT_COMMIT=unknown

--- a/Dockerfile.go
+++ b/Dockerfile.go
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 RUN apk add --no-cache build-base
 


### PR DESCRIPTION
## Summary
- Bumps the Go toolchain used to build/test to 1.27: `golang:1.27-alpine` in `Dockerfile` and `Dockerfile.go`, and `go-version: '1.27'` in the three `actions/setup-go` steps in `.github/workflows/deploy.yml`.
- Each module's `go.mod` `go` directive is intentionally left at `1.22` — no 1.27-only language features are being adopted, and a 1.27 toolchain builds a `go 1.22`-declared module without issue.

## Test plan
- [x] `go build ./...` + `go vet ./...` for all 13 modules (`cmd/server`, `cmd/ingestor`, `cmd/migrate`, `cmd/decrypt`, 10 `internal/*` packages) under Go 1.27.0
- [x] `go test ./...` passes for `cmd/server`, `cmd/ingestor`, `cmd/migrate`, `cmd/decrypt`
- [ ] `docker build` against the new `golang:1.27-alpine` base (Docker wasn't available in the sandbox this change was prepared in — needs a check in CI or locally)