### PR TITLE
ci: match root-level markdown in the docs paths-ignore

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,13 @@ name: CI/CD Pipeline
 # paths-ignore skips only when EVERY changed file matches, so a PR that
 # touches both code and docs still runs the full pipeline.
 #
+# The pattern is '**.md', not '**/*.md'. GitHub's own example for "any file
+# with this extension" is '**.js' with no slash; '**/*.md' reads as requiring
+# a directory component, which would leave root-level files such as
+# CHANGELOG.md and README.md uncovered. Since paths-ignore only skips when
+# EVERY changed file matches, one uncovered root file is enough to run the
+# whole pipeline.
+#
 # Caveat if required status checks are ever enabled on master: a skipped
 # workflow never reports, so a docs-only PR would wait forever on a check
 # that cannot arrive. At that point this needs to become a change-detection
@@ -19,13 +26,13 @@ on:
   push:
     branches: [master]
     paths-ignore:
-      - '**/*.md'
+      - '**.md'
       - 'docs/**'
       - 'LICENSE'
   pull_request:
     branches: [master]
     paths-ignore:
-      - '**/*.md'
+      - '**.md'
       - 'docs/**'
       - 'LICENSE'
   workflow_dispatch:


### PR DESCRIPTION
Follow-up to #1949, correcting a pattern I did not check before proposing it.

#1949 used `'**/*.md'`. That reads as requiring a directory component, so it covers `docs/release-notes/v3.10.0.md` but not `CHANGELOG.md` or `README.md` at the repository root. Since `paths-ignore` skips only when **every** changed file matches, one uncovered root file is enough to run the whole pipeline anyway.

GitHub's own example for "any file with this extension" is `'**.js'`, with no slash. `'**/*.md'` does not appear in their documentation at all. `'**.md'` covers root and subdirectories both.

## What this does not establish

#1948 (`CHANGELOG.md` plus a release note) did start a full run after #1949 landed, and that is what prompted this. But there is a second candidate explanation I did not rule out: that PR's branch predates #1949, so its workflow file may simply not have carried the filter yet.

I am not claiming to have proven which one it was. The fix is correct either way, and shipping the documented pattern is better than defending the first cause I noticed. The real test is the next docs-only PR opened from a branch that already contains the filter.

The reasoning is in a comment above the `on:` block, not only in this description.
