### PR TITLE
docs: renumber the release to v3.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## [Unreleased]
 
-## [3.10.0] - 2026-09-03
+## [3.10.1] - 2026-09-04
 
-See [docs/release-notes/v3.10.0.md](docs/release-notes/v3.10.0.md) for the full notes. 111 commits since v3.9.2, all substantive (no coverage bumps in this range).
+v3.10.0 was tagged and withdrawn before any container image or release asset was published; nothing was ever available under that number. Same release, next number.
+
+See [docs/release-notes/v3.10.1.md](docs/release-notes/v3.10.1.md) for the full notes. 111 commits since v3.9.2, all substantive (no coverage bumps in this range).
 
 ### Highlights
 - **CARTO basemaps need an API key now** (#1919, #1926) - unauthenticated tiles come back watermarked with HTTP 200, so this failed silently. Set `map.tiles.providers.carto.key`. **Operator action required.**
@@ -21,6 +23,10 @@ See [docs/release-notes/v3.10.0.md](docs/release-notes/v3.10.0.md) for the full 
 ### Retention
 - New `observerPurgeDays` for hard-deleting long-inactive observers, disabled by default (#1886).
 - New windows for the opt-in client tables: `retention.clientRxDays`, `clientRxObsDays`, `clientRfDays`.
+
+### CI
+- Documentation-only changes skip the pipeline, with root-level markdown covered by the filter (#1949, #1950).
+- Container images are published on a tag ref and not only on a `push` event, so the release fallback in `release-fast-path.yml` can actually publish (#1951).
 
 ## [3.9.1] — 2026-06-12
 

--- a/docs/release-notes/v3.10.1.md
+++ b/docs/release-notes/v3.10.1.md
@@ -1,8 +1,15 @@
-# CoreScope v3.10.0
+# CoreScope v3.10.1
+
+_v3.10.0 was tagged and then withdrawn before any container image or release
+asset was published, so nothing was ever available under that number. The
+release machinery could not publish an image for it (see #1951), and GitHub's
+immutable releases keep a tag name reserved once used, so this is the same
+release under the next number. Contents are identical apart from three CI
+fixes; no product code differs._
 
 **Upgrade urgency: High for anyone running a map.** CARTO began requiring an API key on its raster basemaps in August 2026, so map tiles on v3.9.2 come back watermarked "API KEY REQUIRED" with an HTTP 200. Nothing errors and no healthcheck fires. This release supports the key; you have to add one. It also restores relay `last_seen`, which has been a no-op since the read-only DB refactor.
 
-_111 commits since v3.9.2 (2026-06-13). No auto-generated coverage bumps in this range, so all 111 are substantive. Every bullet ends with a commit SHA: `git show <sha>` to verify._
+_111 commits since v3.9.2 (2026-06-13), plus the CI fixes listed at the end. No auto-generated coverage bumps in this range, so all 111 are substantive. Every bullet ends with a commit SHA: `git show <sha>` to verify._
 
 ## Highlights
 
@@ -108,6 +115,13 @@ The first one needs action; the rest are defaults you may want to reconsider.
 4. **`observerPurgeDays` is new and disabled by default.** Set it above both `observerDays` and `packetDays`: below those, the reference guards keep every row anyway.
 
 5. **WebSocket origin allowlist.** If you embed CoreScope from another origin, allowlist it or the socket is refused.
+
+## CI fixes carried in this release
+
+These landed after the v3.10.0 tag and are why this release is numbered v3.10.1. None of them touch product code.
+
+- Skip the pipeline for documentation-only changes, and match root-level markdown in that filter. A 16-minute Playwright run to prove a text file does not break a browser was pushing the runs that matter down a queue that ran hours deep. (#1949; #1950)
+- Publish container images on a tag ref, not only on a `push` event. `release-fast-path.yml` falls back to dispatching the full pipeline when it cannot re-tag `:edge`, and that fallback had never been able to publish anything: every GHCR step was gated on `github.event_name == 'push'`, and a dispatch is not a push. It built locally, reported success, and pushed nothing. (#1951)
 
 ## Contributors
 


### PR DESCRIPTION
v3.10.0 was tagged and then withdrawn. **Nothing was ever available under that number**: no container image and no release asset was ever published, so no user could have pulled it.

This renames the notes and the CHANGELOG section. No product code changes.

## Why it had to be renumbered

Three things, in the order they bit.

**1. The image never built.** `release-fast-path.yml` re-tags `:edge` to `:vX.Y.Z` when the `:edge` revision label matches the tagged commit, and dispatches `deploy.yml` when it does not. The tagged commit was documentation-only, so the `paths-ignore` from #1949 meant no `:edge` existed for it and the fallback ran. That part behaved correctly. The fallback then published nothing, because every GHCR step was gated on `github.event_name == 'push'` and a dispatch is not a push. It built locally, reported `success`, and pushed nothing.

Fixed in #1951, but that fix is not in the `v3.10.0` tag, and a `workflow_dispatch` runs the workflow file **from the ref it targets**. So the existing tag could not be made to publish.

**2. The assets never uploaded.** I created the GitHub release by hand before the workflow reached it, and `action-gh-release` cannot update an immutable release. The correct procedure is to push the tag and let the workflow create the release.

**3. The tag name cannot be reused.** GitHub's immutable releases keep a tag name reserved even after the release is deleted:

```
remote: - Cannot create ref due to creations being restricted.
```

I established that only after deleting the release, which is the wrong order. The lesson, written into the commit message so it survives: check whether a tag can be rewritten before removing anything that depends on it.

## What is in v3.10.1

The same 111 commits, plus the three CI fixes that landed after the v3.10.0 tag (#1949, #1950, #1951). Those are listed in their own section in the notes. **No product code differs** from what was tagged as v3.10.0.

All 69 SHA references in the notes were re-verified after the rename.

## Procedure for this tag

Push the tag and stop. The workflow creates the release and attaches the assets. Do not create it by hand.
