### PR TITLE
fix(#1899): scope the channel preview to the region filter

### DIFF
--- a/cmd/server/db.go
+++ b/cmd/server/db.go
@@ -1715,12 +1715,19 @@ func (db *DB) GetChannels(region ...string) ([]map[string]interface{}, error) {
 			args = append(args, code)
 		}
 		regionPlaceholder := strings.Join(placeholders, ",")
+		// #1899: the sample_json subquery is region-scoped too, so its placeholders
+		// appear FIRST in the statement (it sits in the SELECT list, ahead of the
+		// WHERE). Bind the codes twice, subquery set first.
+		args = append(append(make([]interface{}, 0, len(regionCodes)*2), args...), args...)
 		if db.isV3 {
 			querySQL = fmt.Sprintf(`SELECT t.channel_hash,
 					COUNT(*) AS msg_count,
 					MAX(t.first_seen) AS last_activity,
 					(SELECT t2.decoded_json FROM transmissions t2
+					 JOIN observations o2 ON o2.transmission_id = t2.id
+					 LEFT JOIN observers obs2 ON obs2.rowid = o2.observer_idx
 					 WHERE t2.channel_hash = t.channel_hash AND t2.payload_type = 5
+					 AND obs2.rowid IS NOT NULL AND UPPER(TRIM(obs2.iata)) IN (%s)
 					 ORDER BY t2.first_seen DESC LIMIT 1) AS sample_json
 				FROM transmissions t
 				JOIN observations o ON o.transmission_id = t.id
@@ -1730,13 +1737,19 @@ func (db *DB) GetChannels(region ...string) ([]map[string]interface{}, error) {
 				AND t.channel_hash NOT LIKE 'enc_%%'
 				AND obs.rowid IS NOT NULL AND UPPER(TRIM(obs.iata)) IN (%s)
 				GROUP BY t.channel_hash
-				ORDER BY last_activity DESC`, regionPlaceholder)
+				ORDER BY last_activity DESC`, regionPlaceholder, regionPlaceholder)
 		} else {
 			querySQL = fmt.Sprintf(`SELECT t.channel_hash,
 					COUNT(*) AS msg_count,
 					MAX(t.first_seen) AS last_activity,
 					(SELECT t2.decoded_json FROM transmissions t2
+					 JOIN observations o2 ON o2.transmission_id = t2.id
 					 WHERE t2.channel_hash = t.channel_hash AND t2.payload_type = 5
+					 AND EXISTS (
+						SELECT 1 FROM observers obs2
+						WHERE obs2.id = o2.observer_id
+						AND UPPER(TRIM(obs2.iata)) IN (%s)
+					 )
 					 ORDER BY t2.first_seen DESC LIMIT 1) AS sample_json
 				FROM transmissions t
 				JOIN observations o ON o.transmission_id = t.id
@@ -1749,7 +1762,7 @@ func (db *DB) GetChannels(region ...string) ([]map[string]interface{}, error) {
 					AND UPPER(TRIM(obs.iata)) IN (%s)
 				)
 				GROUP BY t.channel_hash
-				ORDER BY last_activity DESC`, regionPlaceholder)
+				ORDER BY last_activity DESC`, regionPlaceholder, regionPlaceholder)
 		}
 	} else {
 		querySQL = `SELECT channel_hash,

--- a/cmd/server/db_test.go
+++ b/cmd/server/db_test.go
@@ -2425,3 +2425,65 @@ func TestDetectSchemaV3AndV2(t *testing.T) {
 	}
 	db2.Close()
 }
+
+// #1899: the sidebar preview must come from the region being filtered on.
+//
+// GetChannels scoped msg_count and last_activity through observations/observers,
+// but the sample_json subquery that feeds lastMessage/lastSender did not join
+// either table. It therefore always returned the globally newest message on the
+// channel, so an operator filtering on their own region saw a preview line from
+// a message their observers never heard.
+func TestGetChannelsPreviewRespectsRegionFilter(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	db.conn.Exec(`INSERT INTO observers (id, name, iata) VALUES ('obs1', 'Observer1', 'SJC')`)
+	db.conn.Exec(`INSERT INTO observers (id, name, iata) VALUES ('obs2', 'Observer2', 'SFO')`)
+
+	// One channel, seen in both regions. The SFO message is the newer one, so it
+	// is what an unscoped preview would show.
+	db.conn.Exec(`INSERT INTO transmissions (raw_hex, hash, first_seen, route_type, payload_type, decoded_json, channel_hash)
+		VALUES ('AA', 'hash1', '2026-01-15T10:00:00Z', 1, 5,
+		'{"type":"CHAN","channel":"#shared","text":"Alice: heard in SJC","sender":"Alice"}', '#shared')`)
+	db.conn.Exec(`INSERT INTO observations (transmission_id, observer_idx, snr, rssi, timestamp)
+		VALUES (1, 1, 12.0, -90, 1736935200)`)
+
+	db.conn.Exec(`INSERT INTO transmissions (raw_hex, hash, first_seen, route_type, payload_type, decoded_json, channel_hash)
+		VALUES ('BB', 'hash2', '2026-01-15T10:05:00Z', 1, 5,
+		'{"type":"CHAN","channel":"#shared","text":"Bob: heard in SFO","sender":"Bob"}', '#shared')`)
+	db.conn.Exec(`INSERT INTO observations (transmission_id, observer_idx, snr, rssi, timestamp)
+		VALUES (2, 2, 14.0, -88, 1736935500)`)
+
+	sjc, err := db.GetChannels("SJC")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sjc) != 1 {
+		t.Fatalf("expected 1 channel for SJC, got %d", len(sjc))
+	}
+	if got := sjc[0]["lastSender"]; got != "Alice" {
+		t.Errorf("preview sender = %v, want Alice: SJC must not be shown Bob's message, "+
+			"which only SFO heard", got)
+	}
+	if got := sjc[0]["lastMessage"]; got != "heard in SJC" {
+		t.Errorf("preview message = %v, want \"heard in SJC\"", got)
+	}
+
+	// The other direction, so the test cannot pass by always picking the oldest.
+	sfo, err := db.GetChannels("SFO")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sfo[0]["lastSender"]; got != "Bob" {
+		t.Errorf("preview sender = %v, want Bob for SFO", got)
+	}
+
+	// Unscoped still shows the globally newest, which was never in question.
+	all, err := db.GetChannels()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := all[0]["lastSender"]; got != "Bob" {
+		t.Errorf("unfiltered preview sender = %v, want Bob (the newest message)", got)
+	}
+}


### PR DESCRIPTION
Closes #1899.

The Channels sidebar preview (`lastMessage` / `lastSender`) ignored the active region filter, so an operator filtering on their own region saw a preview line from a message their observers never heard.

## Cause

`GetChannels` scoped `msg_count` and `last_activity` correctly: the outer query joins `observations` and `observers` and filters on IATA. The `sample_json` subquery that feeds the preview joined neither, so it always returned the globally newest message on the channel.

## Fix

Both region-filtered branches now scope the subquery the way the outer query does: v3 through `observations`/`observers` on `observer_idx`, v2 through the `EXISTS` on `observer_id`. The unfiltered branch is untouched, since there is no filter for it to respect.

**One thing that is easy to get wrong here:** the subquery sits in the SELECT list, *ahead of* the WHERE, so its placeholders bind first. The region codes are appended twice, subquery set first, or every filtered call binds the wrong values.

**Scope checked rather than assumed:** `GetEncryptedChannels` has the same shape and the same `regionPlaceholder` pattern, but selects no `sample_json`, so it does not have this bug and is left alone.

## Verification

The regression test **fails on unmodified master**, with the reported symptom:

```
db_test.go:2465: preview sender = Bob, want Alice: SJC must not be shown Bob's
                 message, which only SFO heard
db_test.go:2469: preview message = heard in SFO, want "heard in SJC"
```

It asserts both directions, so it cannot pass by always picking the oldest row, and it asserts the unfiltered call still shows the globally newest message, which was never in question.

`gofmt` clean, `go vet` clean, `cmd/server` suite ok in 98.5s.
