### PR TITLE
fix(#1896): say that the naive-clock notice clears itself

### DIFF
--- a/public/observers.js
+++ b/public/observers.js
@@ -523,7 +523,7 @@ window.preserveCompareSelection = function preserveCompareSelection(prevIds, tbo
     var content = window.SlideOver.open({ title: (o.name || o.id) });
     var naiveChipHTML = window.ObserversNaiveChip.render(o);
     content.innerHTML =
-      (naiveChipHTML ? '<div style="margin-bottom:10px">' + naiveChipHTML + ' <span class="text-muted">Clock is naive — per-packet timing clamped to ingest time.</span></div>' : '') +
+      (naiveChipHTML ? '<div style="margin-bottom:10px">' + naiveChipHTML + ' <span class="text-muted">Clock is naive — per-packet timing clamped to ingest time. Clears itself 24h after the last skew event.</span></div>' : '') +
       '<dl class="slide-over-dl" style="margin:0;display:grid;grid-template-columns:auto 1fr;gap:6px 12px;font-size:13px">' +
         '<dt>Status</dt><dd><span class="health-dot ' + h.cls + '"><svg class="ph-icon" aria-hidden="true" focusable="false"><use href="/icons/phosphor-sprite.svg#ph-circle-fill"></use></svg></span> ' + h.label + '</dd>' +
         '<dt>Region</dt><dd>' + (o.iata ? '<span class="badge-region">' + o.iata + '</span>' : '—') + '</dd>' +


### PR DESCRIPTION
Closes #1896.

The banner told operators their clock is naive but not that the notice goes away on its own, so people went looking for #1480 to find out. One sentence:

> Clock is naive — per-packet timing clamped to ingest time. **Clears itself 24h after the last skew event.**

## Verified before writing it into the UI

The issue asserts the 24h self-clear. Rather than repeat that, I checked it:

- `cmd/server/observer_naive_clock.go:8` — `const observerNaiveClockWindow = 24 * time.Hour`
- `applyObserverNaiveClock` applies the decay at read time and leaves `clock_naive` false once the last event is older than the window
- its own comment: *"any event older than observerNaiveClockWindow is treated as absent so the chip and banner clear automatically without a background sweep"*

So "24h after the last skew event" is accurate, including the fact that it needs no sweep and no restart.

No test pinned the old string.
