### PR TITLE
perf(#1910): collapse concurrent /stats work and serve the count cache stale

### DIFF
--- a/cmd/server/get_store_stats_cache_test.go
+++ b/cmd/server/get_store_stats_cache_test.go
@@ -42,21 +42,29 @@ func TestGetStoreStats_CacheExpiry(t *testing.T) {
 	store.statsLast24h = 9999
 	store.statsCacheMu.Unlock()
 
-	st, err := store.GetStoreStats()
-	if err != nil {
+	if _, err := store.GetStoreStats(); err != nil {
 		t.Fatalf("GetStoreStats: %v", err)
 	}
-	if st.PacketsLastHour == 9999 || st.PacketsLast24h == 9999 {
-		t.Errorf("stale cache not expired: got PacketsLastHour=%d PacketsLast24h=%d — DB values expected, not sentinel",
-			st.PacketsLastHour, st.PacketsLast24h)
-	}
 
-	store.statsCacheMu.Lock()
-	age := time.Since(store.statsCacheTime)
-	store.statsCacheMu.Unlock()
-	if age > 5*time.Second {
-		t.Errorf("cache not refreshed after expiry: statsCacheTime age=%v", age)
+	// #1910 CHANGED THE CONTRACT HERE. This used to assert that an expired cache
+	// returns fresh DB values on the same call. It now returns the stale value and
+	// refreshes in the background, because making the caller wait for a range scan
+	// over 24h of observations is what produced 10-17s /stats responses under
+	// mixed load. What still has to hold is that the refresh actually happens, so
+	// that is what this asserts. The "served immediately while stale" half is
+	// pinned by TestGetStoreStats_StaleCacheServedWithoutBlocking below.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		store.statsCacheMu.Lock()
+		age := time.Since(store.statsCacheTime)
+		refreshed := store.statsLastHour != 9999 && store.statsLast24h != 9999
+		store.statsCacheMu.Unlock()
+		if refreshed && age < 5*time.Second {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
+	t.Error("cache not refreshed after expiry: the sentinel is still in place")
 }
 
 // TestGetStoreStats_CacheConcurrentReaders verifies that 100 concurrent
@@ -81,5 +89,96 @@ func TestGetStoreStats_CacheConcurrentReaders(t *testing.T) {
 	close(errs)
 	for err := range errs {
 		t.Errorf("concurrent GetStoreStats: %v", err)
+	}
+}
+
+// #1910: a stale observation-count cache must be served immediately, with the
+// refresh happening in the background, instead of making the caller wait for a
+// range scan over 24h of observations.
+//
+// Before this, an expired cache meant every concurrent request ran that scan
+// itself, because the cache check releases statsCacheMu before doing the work.
+// On a deployment with 18k observers /stats was measured at 10-17s under the
+// mixed load an Observers page load produces, while staying under 70ms when it
+// was the only endpoint being hit.
+//
+// The test seeds the cache with values the database cannot produce, then makes
+// it stale. If the stale value comes back, the caller was not made to wait.
+func TestGetStoreStats_StaleCacheServedWithoutBlocking(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	store := srv.store
+
+	const sentinelHour, sentinelDay = 424242, 434343
+
+	store.statsCacheMu.Lock()
+	store.statsLastHour = sentinelHour
+	store.statsLast24h = sentinelDay
+	store.statsCacheTime = time.Now().Add(-90 * time.Second) // well past the 30s TTL
+	store.statsCacheMu.Unlock()
+
+	st, err := store.GetStoreStats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.PacketsLastHour != sentinelHour || st.PacketsLast24h != sentinelDay {
+		t.Errorf("stale cache not served: got (%d, %d), want (%d, %d). "+
+			"An expired cache must answer from the previous value and refresh in the "+
+			"background, not block the request on the observations scan",
+			st.PacketsLastHour, st.PacketsLast24h, sentinelHour, sentinelDay)
+	}
+
+	// The background refresh should then replace the sentinel with a real count.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		store.statsCacheMu.Lock()
+		refreshed := store.statsLastHour != sentinelHour || store.statsLast24h != sentinelDay
+		store.statsCacheMu.Unlock()
+		if refreshed {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Error("background refresh never replaced the stale value; serving stale is only " +
+		"acceptable because a refresh follows it")
+}
+
+// #1910: concurrent cold-cache callers must agree, which they cannot do if each
+// runs its own scan against a moving table.
+func TestGetStoreStats_ConcurrentColdCallersAgree(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	store := srv.store
+
+	store.statsCacheMu.Lock()
+	store.statsCacheTime = time.Time{} // cold
+	store.statsCacheMu.Unlock()
+
+	const n = 50
+	var wg sync.WaitGroup
+	results := make(chan [2]int, n)
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			st, err := store.GetStoreStats()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			results <- [2]int{st.PacketsLastHour, st.PacketsLast24h}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var first [2]int
+	seen := false
+	for r := range results {
+		if !seen {
+			first, seen = r, true
+			continue
+		}
+		if r != first {
+			t.Errorf("concurrent callers disagreed: %v vs %v", r, first)
+		}
 	}
 }

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/meshcore-analyzer/prunequeue"
+	"golang.org/x/sync/singleflight"
 )
 
 // memBreakdownNote is the static accounting caveat attached to the opt-in
@@ -47,6 +48,11 @@ type Server struct {
 	statsMu       sync.Mutex
 	statsCache    *StatsResponse
 	statsCachedAt time.Time
+	// #1910: collapses concurrent rebuilds. The cache check below releases
+	// statsMu before building the response, so every request arriving while the
+	// 10s window was expired used to rebuild it in full, each running its own DB
+	// queries against a 4-connection pool.
+	statsSF singleflight.Group
 
 	// Guards s.cfg.GeoFilter — read by ingest/handler goroutines, written by PUT handler
 	cfgMu sync.RWMutex
@@ -780,66 +786,86 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 	}
 	s.statsMu.Unlock()
 
-	var stats *Stats
-	var err error
-	if s.store != nil {
-		stats, err = s.store.GetStoreStats()
-	} else {
-		stats, err = s.db.GetStats()
-	}
-	if err != nil {
-		writeError(w, 500, err.Error())
+	// #1910: one rebuild per expiry, not one per request. Everything below runs
+	// inside singleflight, so concurrent callers that miss the cache wait for the
+	// first one's response instead of each running the same DB queries against a
+	// 4-connection pool.
+	built, sfErr, _ := s.statsSF.Do("stats", func() (interface{}, error) {
+		// Re-check under the group: the winner may have just filled the cache.
+		s.statsMu.Lock()
+		if s.statsCache != nil && time.Since(s.statsCachedAt) < statsTTL {
+			cached := s.statsCache
+			s.statsMu.Unlock()
+			return cached, nil
+		}
+		s.statsMu.Unlock()
+
+		var stats *Stats
+		var err error
+		if s.store != nil {
+			stats, err = s.store.GetStoreStats()
+		} else {
+			stats, err = s.db.GetStats()
+		}
+		if err != nil {
+			return nil, err
+		}
+		counts := s.db.GetRoleCounts()
+
+		// Memory accounting (#832). storeDataMB is the in-store packet byte
+		// estimate (the old "trackedMB"); processRSSMB / goHeapInuseMB / goSysMB
+		// give ops the breakdown needed to reason about real RSS. All values
+		// share a single 1s-cached snapshot to amortize ReadMemStats cost.
+		var storeDataMB float64
+		if s.store != nil {
+			storeDataMB = s.store.trackedMemoryMB()
+		}
+		mem := s.getMemorySnapshot(storeDataMB)
+
+		resp := &StatsResponse{
+			TotalPackets:       stats.TotalPackets,
+			TotalTransmissions: &stats.TotalTransmissions,
+			TotalObservations:  stats.TotalObservations,
+			TotalNodes:         stats.TotalNodes,
+			TotalNodesAllTime:  stats.TotalNodesAllTime,
+			TotalObservers:     stats.TotalObservers,
+			PacketsLastHour:    stats.PacketsLastHour,
+			PacketsLast24h:     stats.PacketsLast24h,
+			Engine:             "go",
+			Version:            s.version,
+			Commit:             s.commit,
+			BuildTime:          s.buildTime,
+			Counts: RoleCounts{
+				Repeaters:  counts["repeaters"],
+				Rooms:      counts["rooms"],
+				Companions: counts["companions"],
+				Sensors:    counts["sensors"],
+			},
+			SignatureDrops:        s.db.GetSignatureDropCount(),
+			HashMigrationComplete: s.store != nil && s.store.hashMigrationComplete.Load(),
+
+			TrackedMB:     mem.StoreDataMB, // deprecated alias
+			StoreDataMB:   mem.StoreDataMB,
+			ProcessRSSMB:  mem.ProcessRSSMB,
+			GoHeapInuseMB: mem.GoHeapInuseMB,
+			GoSysMB:       mem.GoSysMB,
+
+			NeighborGraphCacheRebuildFailures: atomic.LoadUint64(&s.neighborGraphCacheRebuildFailures),
+		}
+
+		s.statsMu.Lock()
+		s.statsCache = resp
+		s.statsCachedAt = time.Now()
+		s.statsMu.Unlock()
+
+		return resp, nil
+	})
+	if sfErr != nil {
+		writeError(w, 500, sfErr.Error())
 		return
 	}
-	counts := s.db.GetRoleCounts()
 
-	// Memory accounting (#832). storeDataMB is the in-store packet byte
-	// estimate (the old "trackedMB"); processRSSMB / goHeapInuseMB / goSysMB
-	// give ops the breakdown needed to reason about real RSS. All values
-	// share a single 1s-cached snapshot to amortize ReadMemStats cost.
-	var storeDataMB float64
-	if s.store != nil {
-		storeDataMB = s.store.trackedMemoryMB()
-	}
-	mem := s.getMemorySnapshot(storeDataMB)
-
-	resp := &StatsResponse{
-		TotalPackets:       stats.TotalPackets,
-		TotalTransmissions: &stats.TotalTransmissions,
-		TotalObservations:  stats.TotalObservations,
-		TotalNodes:         stats.TotalNodes,
-		TotalNodesAllTime:  stats.TotalNodesAllTime,
-		TotalObservers:     stats.TotalObservers,
-		PacketsLastHour:    stats.PacketsLastHour,
-		PacketsLast24h:     stats.PacketsLast24h,
-		Engine:             "go",
-		Version:            s.version,
-		Commit:             s.commit,
-		BuildTime:          s.buildTime,
-		Counts: RoleCounts{
-			Repeaters:  counts["repeaters"],
-			Rooms:      counts["rooms"],
-			Companions: counts["companions"],
-			Sensors:    counts["sensors"],
-		},
-		SignatureDrops:        s.db.GetSignatureDropCount(),
-		HashMigrationComplete: s.store != nil && s.store.hashMigrationComplete.Load(),
-
-		TrackedMB:     mem.StoreDataMB, // deprecated alias
-		StoreDataMB:   mem.StoreDataMB,
-		ProcessRSSMB:  mem.ProcessRSSMB,
-		GoHeapInuseMB: mem.GoHeapInuseMB,
-		GoSysMB:       mem.GoSysMB,
-
-		NeighborGraphCacheRebuildFailures: atomic.LoadUint64(&s.neighborGraphCacheRebuildFailures),
-	}
-
-	s.statsMu.Lock()
-	s.statsCache = resp
-	s.statsCachedAt = time.Now()
-	s.statsMu.Unlock()
-
-	writeJSON(w, resp)
+	writeJSON(w, built.(*StatsResponse))
 }
 
 func (s *Server) handlePerf(w http.ResponseWriter, r *http.Request) {

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/meshcore-analyzer/mbcapqueue"
+	"golang.org/x/sync/singleflight"
 )
 
 // payloadTypeNames maps payload_type int → human-readable name (firmware-standard).
@@ -490,6 +491,12 @@ type PacketStore struct {
 	statsCacheTime time.Time
 	statsLastHour  int
 	statsLast24h   int
+	// #1910: collapses concurrent misses onto one query. Without it every
+	// in-flight request ran the observations scan itself the moment the cache
+	// expired, because the check above releases statsCacheMu before doing the
+	// work. With SetMaxOpenConns(4) and a page that fires five endpoints at
+	// once, that turned one scan into a queue of them.
+	statsSF singleflight.Group
 
 	// Test-only hook fired at the very start of loadBackgroundChunks
 	// (after the #1809 invariant check). Nil in production. Used by
@@ -2038,17 +2045,32 @@ func (s *PacketStore) GetStoreStats() (*Stats, error) {
 	oneHourAgo := time.Now().Add(-1 * time.Hour).Unix()
 	oneDayAgo := time.Now().Add(-24 * time.Hour).Unix()
 
-	// Serve observation counts from cache if fresh (avoids per-request full-table scan).
+	// Observation counts (#1910). Three cases, and only the cold one makes the
+	// caller wait:
+	//   fresh  — serve the cache.
+	//   stale  — serve the cache anyway and refresh once in the background. A
+	//            count that is half a minute old is not worth a page that hangs.
+	//   cold   — compute, but under singleflight, so N concurrent callers share
+	//            one scan instead of each running their own.
 	var obsFromCache bool
 	s.statsCacheMu.Lock()
-	if !s.statsCacheTime.IsZero() && time.Since(s.statsCacheTime) < 30*time.Second {
+	haveObsCache := !s.statsCacheTime.IsZero()
+	obsCacheFresh := haveObsCache && time.Since(s.statsCacheTime) < 30*time.Second
+	if haveObsCache {
 		st.PacketsLastHour = s.statsLastHour
 		st.PacketsLast24h = s.statsLast24h
-		obsFromCache = true
 	}
 	s.statsCacheMu.Unlock()
 
-	// Run node/observer counts and (if cache miss) observation counts concurrently.
+	switch {
+	case obsCacheFresh:
+		obsFromCache = true
+	case haveObsCache:
+		obsFromCache = true
+		go func() { _, _, _ = s.refreshObsCounts(oneHourAgo, oneDayAgo) }()
+	}
+
+	// Run node/observer counts and (if cold) observation counts concurrently.
 	var wg sync.WaitGroup
 	var nodeErr, obsErr error
 
@@ -2069,19 +2091,11 @@ func (s *PacketStore) GetStoreStats() (*Stats, error) {
 	if !obsFromCache {
 		go func() {
 			defer wg.Done()
-			obsErr = s.db.conn.QueryRow(
-				`SELECT
-					COALESCE(SUM(CASE WHEN timestamp > ? THEN 1 ELSE 0 END), 0),
-					COALESCE(SUM(CASE WHEN timestamp > ? THEN 1 ELSE 0 END), 0)
-				FROM observations WHERE timestamp > ?`,
-				oneHourAgo, oneDayAgo, oneDayAgo,
-			).Scan(&st.PacketsLastHour, &st.PacketsLast24h)
-			if obsErr == nil {
-				s.statsCacheMu.Lock()
-				s.statsLastHour = st.PacketsLastHour
-				s.statsLast24h = st.PacketsLast24h
-				s.statsCacheTime = time.Now()
-				s.statsCacheMu.Unlock()
+			lastHour, last24h, err := s.refreshObsCounts(oneHourAgo, oneDayAgo)
+			obsErr = err
+			if err == nil {
+				st.PacketsLastHour = lastHour
+				st.PacketsLast24h = last24h
 			}
 		}()
 	}
@@ -2095,6 +2109,42 @@ func (s *PacketStore) GetStoreStats() (*Stats, error) {
 	}
 
 	return st, nil
+}
+
+// refreshObsCounts runs the observations range scan for the last hour and the
+// last 24h, and writes the result into the stats cache.
+//
+// #1910: wrapped in singleflight. The cache check in GetStoreStats releases
+// statsCacheMu before doing the work, so every request that arrived while the
+// cache was expired used to run this scan itself. With SetMaxOpenConns(4) and a
+// page that fires stats, observers, nodes, channels and clock-skew at once, that
+// turned one scan into a queue of them: /stats was measured at 10-17s under
+// mixed load while staying under 70ms when it was the only endpoint being hit.
+// Now the second and later callers wait for the first one's result.
+func (s *PacketStore) refreshObsCounts(oneHourAgo, oneDayAgo int64) (int, int, error) {
+	v, err, _ := s.statsSF.Do("obs-counts", func() (interface{}, error) {
+		var lastHour, last24h int
+		if qErr := s.db.conn.QueryRow(
+			`SELECT
+				COALESCE(SUM(CASE WHEN timestamp > ? THEN 1 ELSE 0 END), 0),
+				COALESCE(SUM(CASE WHEN timestamp > ? THEN 1 ELSE 0 END), 0)
+			FROM observations WHERE timestamp > ?`,
+			oneHourAgo, oneDayAgo, oneDayAgo,
+		).Scan(&lastHour, &last24h); qErr != nil {
+			return nil, qErr
+		}
+		s.statsCacheMu.Lock()
+		s.statsLastHour = lastHour
+		s.statsLast24h = last24h
+		s.statsCacheTime = time.Now()
+		s.statsCacheMu.Unlock()
+		return [2]int{lastHour, last24h}, nil
+	})
+	if err != nil {
+		return 0, 0, err
+	}
+	pair := v.([2]int)
+	return pair[0], pair[1], nil
 }
 
 // GetPerfStoreStats returns packet store statistics for /api/perf.


### PR DESCRIPTION
Addresses #1910. The Observers page hangs on "Loading..." for 10-20s; the reporter measured `/stats` at 10-17s under the mixed load that page produces, while the same endpoint stays under 70ms at 8x concurrency when it is the only one being hit.

## Cause

Two cache layers guard the expensive work and **neither has single-flight**:

| | | |
|---|---|---|
| `handleStats` | 10s cache | releases `statsMu` before rebuilding (`routes.go:774`) |
| `GetStoreStats` | 30s cache | releases `statsCacheMu` before scanning (`store.go:2048`) |

Both do check, release, then work. The moment either window expires, **every in-flight request does the whole thing itself**.

The expensive part is a range scan over 24h of `observations` with two `SUM(CASE...)` over it. The column is indexed (`idx_observations_timestamp`), but the scan still visits every row in the window, and at 18k observers that is millions. The pool is `SetMaxOpenConns(4)` (`db.go:111`), and the page fires stats, observers, nodes, channels and clock-skew at once, so one cache miss turns a single scan into a queue of them.

That is exactly the reported profile: fast alone, slow only when mixed.

## Changes

1. **Single-flight both layers.** Concurrent callers that miss the cache wait for the first one's result instead of each running the same queries.
2. **Serve the observation counts stale while refreshing in the background.** An expired cache answers from the previous value and kicks off one refresh, so a miss is never a wait.

Single-flight alone would not have fixed the hang: the first caller still waits for the full scan. The second change is what removes it.

## Contract change, stated plainly

`TestGetStoreStats_CacheExpiry` asserted that an expired cache returns **fresh DB values on the same call**. It no longer does.

For `packetsLastHour` / `packetsLast24h` on a dashboard, answering with a value up to ~30s older instead of blocking for seconds looks like the right trade to me. But that is a judgement, not a bug fix, and **a reviewer should be able to reject it**. I did not quietly delete the test: it now asserts what still has to hold, that the refresh happens, and the new behaviour is pinned separately by `TestGetStoreStats_StaleCacheServedWithoutBlocking`.

If you would rather keep the old contract, drop change 2 and keep change 1; the diff separates cleanly.

## Verification

The new test **fails without the change**:

```
stale cache not served: got (0, 2), want (424242, 434343). An expired cache must
answer from the previous value and refresh in the background, not block the
request on the observations scan
```

`gofmt` clean, `go vet` clean, `cmd/server` suite ok in 267s.

## Two things I did not verify

**The race detector.** It needs cgo and there is no gcc on this machine, so `go test -race` cannot run here. This change adds a background goroutine writing the cache under `statsCacheMu`, so that check matters. CI runs `go test -timeout 20m -race` for `cmd/server` (`deploy.yml:134`), which covers it before merge.

**The 10-17s itself.** I have no database with 18k observers. The mechanism above explains the reported profile, including why the endpoint is fast in isolation, but I did not measure the figure. @dborup, if you can run a build from this branch, the number to watch is `/stats` under the same mixed-load command from your issue.
