### PR TITLE
fix: remove evicted resolved path hops and preserve relay snapshots

### DIFF
--- a/cmd/server/coverage_test.go
+++ b/cmd/server/coverage_test.go
@@ -2705,7 +2705,12 @@ func TestHandleAnalyticsSubpathsWithStore(t *testing.T) {
 	hub := NewHub()
 	srv := NewServer(db, cfg, hub)
 	store := NewPacketStore(db, nil)
-	store.Load()
+	if err := store.Load(); err != nil {
+		t.Fatalf("store.Load failed: %v", err)
+	}
+	if !store.WaitIndexesReady(5 * time.Second) {
+		t.Fatal("indexes not ready after 5s")
+	}
 	srv.store = store
 	router := mux.NewRouter()
 	srv.RegisterRoutes(router)
@@ -2725,7 +2730,12 @@ func TestHandleAnalyticsSubpathDetailWithStore(t *testing.T) {
 	hub := NewHub()
 	srv := NewServer(db, cfg, hub)
 	store := NewPacketStore(db, nil)
-	store.Load()
+	if err := store.Load(); err != nil {
+		t.Fatalf("store.Load failed: %v", err)
+	}
+	if !store.WaitIndexesReady(5 * time.Second) {
+		t.Fatal("indexes not ready after 5s")
+	}
 	srv.store = store
 	router := mux.NewRouter()
 	srv.RegisterRoutes(router)

--- a/cmd/server/index_ready_1008_test.go
+++ b/cmd/server/index_ready_1008_test.go
@@ -58,8 +58,12 @@ func TestIssue1008_HandlerReturns503WhileSubpathIndexLoading(t *testing.T) {
 	if err := store.Load(); err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
-	// Don't wait for the background build — we want to observe the
-	// not-ready window.
+	// Finish the background build before simulating not-ready, so it cannot
+	// flip the flag back to true before the handler checks it.
+	if !store.WaitIndexesReady(5 * time.Second) {
+		t.Fatal("background builds never finished")
+	}
+	store.subpathReady.Store(false)
 	cfg := &Config{}
 	cfg.applyListLimitsDefaults()
 	srv := &Server{store: store, cfg: cfg}

--- a/cmd/server/pathhop_eviction_1908_test.go
+++ b/cmd/server/pathhop_eviction_1908_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPathHopEviction1908(t *testing.T) {
+	for _, mode := range []string{"time-direct", "time-run", "memory-empty-batch", "memory-index-disabled"} {
+		t.Run(mode, func(t *testing.T) {
+			now := time.Now().UTC()
+			store := makeTestStore(8, now.Add(-30*time.Minute), 0)
+			store.byPayloadType[5] = store.byPayloadType[4]
+			delete(store.byPayloadType, 4)
+			store.byPathHop = make(map[string][]*StoreTx)
+			store.useResolvedPathIndex = mode != "memory-index-disabled"
+			store.initResolvedPathIndex()
+			store.retentionHours = 1
+			if strings.HasPrefix(mode, "memory-") {
+				store.maxMemoryMB = 1
+				store.trackedBytes = 8 * 1048576 // The 25% cap evicts the first two.
+			} else {
+				for _, tx := range store.packets[:2] {
+					tx.FirstSeen = now.Add(-2 * time.Hour).Format(time.RFC3339)
+				}
+			}
+
+			shared := strings.Repeat("a", 64)
+			expiredOnly := strings.Repeat("b", 64)
+			retainedOnly := strings.Repeat("c", 64)
+			expiredScope, retainedScope := "expired-scope", "retained-scope"
+			hopsSeen := make(map[string]bool)
+			for i, tx := range store.packets {
+				*tx.PayloadType = 5 // Non-advert traffic contributes to relay stats.
+				pk := retainedOnly
+				tx.ScopeName = &retainedScope
+				if i < 2 {
+					pk = expiredOnly
+					tx.ScopeName = &expiredScope
+				}
+				addTxToPathHopIndex(store.byPathHop, tx)
+				store.indexResolvedPathHops(tx, []string{shared, pk}, hopsSeen)
+			}
+			// Repeated observations can append the same resolved association again.
+			store.indexResolvedPathHops(store.packets[0], []string{shared, expiredOnly}, hopsSeen)
+			store.indexResolvedPathHops(store.packets[7], []string{shared}, hopsSeen)
+			addTxToPathHopIndex(store.byPathHop, store.packets[0])
+
+			// Keep the original backing arrays observable: a shortened slice must
+			// not hide pointers that keep evicted transmissions alive for the GC.
+			backingArrays := make(map[string][]*StoreTx, len(store.byPathHop))
+			for key, list := range store.byPathHop {
+				backingArrays[key] = list[:cap(list)]
+			}
+			before := store.GetRepeaterNodeStatsBatchCached([]string{shared}, 24)[shared].Info
+			if before.RelayCount24h != 8 || len(before.TransportedScopes) != 2 {
+				t.Fatalf("fixture must index all transmissions and scopes: %+v", before)
+			}
+
+			var evicted int
+			if mode == "time-run" {
+				evicted = store.RunEviction() // No DB: cleanup cannot depend on SQL.
+			} else {
+				store.mu.Lock()
+				if strings.HasPrefix(mode, "memory-") {
+					evicted = store.EvictStaleWithRP(map[int][]string{})
+				} else {
+					evicted = store.EvictStale()
+				}
+				store.mu.Unlock()
+			}
+			if evicted != 2 {
+				t.Fatalf("evicted %d transmissions, want 2", evicted)
+			}
+
+			expected := map[string][]int{
+				"aa":         {3, 4, 5, 6, 7, 8},
+				"bb":         {3, 4, 5, 6, 7, 8},
+				"cc":         {3, 4, 5, 6, 7, 8},
+				shared:       {3, 4, 5, 6, 7, 8, 8},
+				retainedOnly: {3, 4, 5, 6, 7, 8},
+			}
+			if len(store.byPathHop) != len(expected) {
+				t.Errorf("path-hop index has %d keys, want %d (expired-only keys must disappear)", len(store.byPathHop), len(expected))
+			}
+			for key, want := range expected {
+				var ids []int
+				for _, tx := range store.byPathHop[key] {
+					ids = append(ids, tx.ID)
+				}
+				if !reflect.DeepEqual(ids, want) {
+					t.Errorf("path-hop bucket %q = %v, want %v", key, ids, want)
+				}
+			}
+			for key, list := range backingArrays {
+				for _, tx := range list {
+					if tx != nil && tx.ID <= 2 {
+						t.Errorf("backing array for %q still retains evicted tx %d", key, tx.ID)
+						break
+					}
+				}
+			}
+			if store.relayStatsCache != nil {
+				t.Error("eviction must invalidate the relay-stats cache")
+			}
+			after := store.GetRepeaterNodeStatsBatchCached([]string{shared}, 24)[shared].Info
+			if after.RelayCount24h != 6 {
+				t.Errorf("relay count after eviction = %d, want 6", after.RelayCount24h)
+			}
+			if !reflect.DeepEqual(after.TransportedScopes, []string{retainedScope}) {
+				t.Errorf("transported scopes after eviction = %v, want only retained scope", after.TransportedScopes)
+			}
+
+			// A later sweep that removes every survivor must also remove every key.
+			for _, tx := range store.packets {
+				tx.FirstSeen = now.Add(-2 * time.Hour).Format(time.RFC3339)
+			}
+			if got := store.RunEviction(); got != 6 {
+				t.Fatalf("final eviction removed %d transmissions, want 6", got)
+			}
+			if len(store.byPathHop) != 0 {
+				t.Errorf("empty store retains %d path-hop keys", len(store.byPathHop))
+			}
+		})
+	}
+}
+
+// Benchmark the eviction path with 8 raw and 8 resolved hops per transmission,
+// 2 observations each, and 2,048 resolved relays sharing 256 raw-prefix buckets.
+// Other secondary indexes are omitted to isolate path-hop cleanup cost. Setup
+// is outside the timer; the timed operation includes acquiring the store lock.
+func BenchmarkPathHopEviction1908(b *testing.B) {
+	const hops = 8
+	pubkeys := make([]string, 2048)
+	for i := range pubkeys {
+		pubkeys[i] = fmt.Sprintf("%02x%062x", i%256, i)
+	}
+	for _, count := range []int{30000, 100000} {
+		for _, evictCount := range []int{1, count / 10, count / 4} {
+			b.Run(fmt.Sprintf("tx=%d/evict=%d", count, evictCount), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+					now := time.Now().UTC()
+					old := now.Add(-2 * time.Hour).Format(time.RFC3339)
+					recent := now.Add(-30 * time.Minute).Format(time.RFC3339)
+					store := &PacketStore{
+						packets:        make([]*StoreTx, count),
+						byPathHop:      make(map[string][]*StoreTx, len(pubkeys)+256),
+						spIndex:        make(map[string]int),
+						retentionHours: 1,
+					}
+					hopsSeen := make(map[string]bool, hops*2)
+					for j := range store.packets {
+						tx := &StoreTx{ID: j + 1, FirstSeen: recent, parsedPath: make([]string, hops), pathParsed: true}
+						if j < evictCount {
+							tx.FirstSeen = old
+						}
+						tx.Observations = []*StoreObs{{ID: j * 2}, {ID: j*2 + 1}}
+						resolved := make([]string, hops)
+						for k := range resolved {
+							resolved[k] = pubkeys[(j*17+k*13)%len(pubkeys)]
+							tx.parsedPath[k] = resolved[k][:2]
+						}
+						store.packets[j] = tx
+						addTxToPathHopIndex(store.byPathHop, tx)
+						store.addResolvedPubkeysToPathHopIndex(tx, resolved, hopsSeen)
+					}
+					b.StartTimer()
+					store.mu.Lock()
+					got := store.EvictStale()
+					store.mu.Unlock()
+					b.StopTimer()
+					if got != evictCount {
+						b.Fatalf("evicted %d transmissions, want %d", got, evictCount)
+					}
+				}
+				b.ReportMetric(float64(count*hops*2), "entries/batch")
+			})
+		}
+	}
+}

--- a/cmd/server/repeater_enrich_bulk.go
+++ b/cmd/server/repeater_enrich_bulk.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"slices"
 	"strings"
 	"time"
 )
@@ -52,12 +53,14 @@ func (s *PacketStore) GetRepeaterRelayInfoMap(windowHours float64) map[string]Re
 	return cached
 }
 
-// snapshotPathHopIndexLocked snapshots the hop buckets for bulk relay reads.
-// The caller must hold s.mu for reading.
+// snapshotPathHopIndexLocked copies hop buckets for reads after releasing s.mu.
+// Eviction and raw-path updates compact their backing arrays in place, so a
+// header copy would allow those writers to change an in-flight snapshot.
+// The caller must hold s.mu for reading. Cost: O(total path-hop entries).
 func (s *PacketStore) snapshotPathHopIndexLocked() map[string][]*StoreTx {
 	snap := make(map[string][]*StoreTx, len(s.byPathHop))
 	for k, list := range s.byPathHop {
-		snap[k] = list
+		snap[k] = slices.Clone(list)
 	}
 	return snap
 }
@@ -67,16 +70,14 @@ func (s *PacketStore) snapshotPathHopIndexLocked() map[string][]*StoreTx {
 // and emits one RepeaterRelayInfo per hop key.
 //
 // Time-complexity invariant: O(unique-tx-in-byPathHop + total-key-bucket
-// entries). Memory: one map entry per byPathHop key. Both are bounded by
-// the same eviction policy that bounds byPathHop itself.
+// entries). Snapshot memory: one pointer per bucket entry, plus a map entry
+// per key; both are bounded by the same eviction policy as byPathHop itself.
 func (s *PacketStore) computeRepeaterRelayInfoMap(windowHours float64) map[string]RepeaterRelayInfo {
 	s.mu.RLock()
 
-	// Snapshot the slices (header copy) so we can release the lock before
-	// the expensive parse pass. Slice headers point at the live underlying
-	// arrays but those are append-only-by-id; the worst-case race here is
-	// that ingest grows a slice we already snapshotted (we miss the new
-	// tail), which is acceptable for a 15s-TTL status read.
+	// Own the bucket arrays before releasing the lock for aggregation.
+	// The result represents this snapshot even if eviction removes its txs
+	// while aggregation runs; the next recomputer pass picks up that change.
 	snap := s.snapshotPathHopIndexLocked()
 
 	// Build a tx-id-keyed pre-parsed cache so the inner loop doesn't

--- a/cmd/server/repeater_enrich_bulk.go
+++ b/cmd/server/repeater_enrich_bulk.go
@@ -52,6 +52,16 @@ func (s *PacketStore) GetRepeaterRelayInfoMap(windowHours float64) map[string]Re
 	return cached
 }
 
+// snapshotPathHopIndexLocked snapshots the hop buckets for bulk relay reads.
+// The caller must hold s.mu for reading.
+func (s *PacketStore) snapshotPathHopIndexLocked() map[string][]*StoreTx {
+	snap := make(map[string][]*StoreTx, len(s.byPathHop))
+	for k, list := range s.byPathHop {
+		snap[k] = list
+	}
+	return snap
+}
+
 // computeRepeaterRelayInfoMap walks byPathHop once under a single RLock,
 // pre-parses every FirstSeen timestamp once (not once-per-pubkey-bucket),
 // and emits one RepeaterRelayInfo per hop key.
@@ -67,10 +77,7 @@ func (s *PacketStore) computeRepeaterRelayInfoMap(windowHours float64) map[strin
 	// arrays but those are append-only-by-id; the worst-case race here is
 	// that ingest grows a slice we already snapshotted (we miss the new
 	// tail), which is acceptable for a 15s-TTL status read.
-	snap := make(map[string][]*StoreTx, len(s.byPathHop))
-	for k, list := range s.byPathHop {
-		snap[k] = list
-	}
+	snap := s.snapshotPathHopIndexLocked()
 
 	// Build a tx-id-keyed pre-parsed cache so the inner loop doesn't
 	// re-parse the same FirstSeen N times when the same tx is indexed

--- a/cmd/server/repeater_snapshot_1908_test.go
+++ b/cmd/server/repeater_snapshot_1908_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// Synthetic traffic: eight resolved relays and their raw prefixes per tx.
+func relaySnapshotStore1908(count, nodes, expired int) *PacketStore {
+	pubkeys := make([]string, nodes)
+	for i := range pubkeys {
+		pubkeys[i] = fmt.Sprintf("%02x%062x", i%256, i)
+	}
+	now := time.Now().UTC()
+	old := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	recent := now.Add(-30 * time.Minute).Format(time.RFC3339)
+	store := &PacketStore{
+		packets:        make([]*StoreTx, count),
+		byPathHop:      make(map[string][]*StoreTx, nodes+256),
+		spIndex:        make(map[string]int),
+		retentionHours: 1,
+	}
+	pt := 5
+	hopsSeen := make(map[string]bool, 16)
+	for i := range store.packets {
+		tx := &StoreTx{ID: i + 1, FirstSeen: recent, PayloadType: &pt, parsedPath: make([]string, 8), pathParsed: true}
+		if i < expired {
+			tx.FirstSeen = old
+		}
+		resolved := make([]string, 8)
+		for hop := range resolved {
+			resolved[hop] = pubkeys[(i*17+hop*13)%nodes]
+			tx.parsedPath[hop] = resolved[hop][:2]
+		}
+		store.packets[i] = tx
+		addTxToPathHopIndex(store.byPathHop, tx)
+		store.addResolvedPubkeysToPathHopIndex(tx, resolved, hopsSeen)
+	}
+	return store
+}
+
+func TestRelaySnapshotSurvivesEviction1908(t *testing.T) {
+	store := relaySnapshotStore1908(4, 8, 2)
+	store.mu.RLock()
+	snapshot := store.snapshotPathHopIndexLocked()
+	store.mu.RUnlock()
+	if len(snapshot) != 16 {
+		t.Fatalf("snapshot has %d buckets, want eight raw and eight resolved", len(snapshot))
+	}
+	if got := store.RunEviction(); got != 2 {
+		t.Fatalf("evicted %d transmissions, want 2", got)
+	}
+	for key, list := range snapshot {
+		if len(list) != 4 {
+			t.Fatalf("snapshot bucket %q has %d transmissions, want 4", key, len(list))
+		}
+		for i, tx := range list {
+			if tx == nil || tx.ID != i+1 {
+				t.Errorf("eviction changed snapshot bucket %q at slot %d: got %v, want tx %d", key, i, tx, i+1)
+				break
+			}
+		}
+	}
+}
+
+func TestRelayComputeConcurrentEviction1908(t *testing.T) {
+	store := relaySnapshotStore1908(30000, 256, 1)
+	key := fmt.Sprintf("%064x", 0)
+	want := len(store.byPathHop[key])
+	result := make(chan map[string]RepeaterRelayInfo, 1)
+	go func() { result <- store.computeRepeaterRelayInfoMap(24) }()
+
+	// Observe the actual reader holding RLock, then queue eviction behind it.
+	// Eviction and the unlocked aggregation must safely use separate buckets.
+	deadline := time.Now().Add(5 * time.Second)
+	for store.mu.TryLock() {
+		store.mu.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatal("relay computation did not acquire the snapshot lock")
+		}
+		runtime.Gosched()
+	}
+	if got := store.RunEviction(); got != 1 {
+		t.Fatalf("evicted %d transmissions, want 1", got)
+	}
+	got := <-result
+	if got[key].RelayCount24h != want {
+		t.Errorf("in-flight relay snapshot count = %d, want %d", got[key].RelayCount24h, want)
+	}
+}
+
+func BenchmarkRelaySnapshot1908(b *testing.B) {
+	for _, size := range []struct{ tx, nodes int }{{30000, 50}, {30000, 2000}, {100000, 2000}} {
+		store := relaySnapshotStore1908(size.tx, size.nodes, 0)
+		b.Run(fmt.Sprintf("tx=%d/nodes=%d", size.tx, size.nodes), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				store.mu.RLock()
+				snapshot := store.snapshotPathHopIndexLocked()
+				store.mu.RUnlock()
+				if len(snapshot) != len(store.byPathHop) {
+					b.Fatal("snapshot lost a hop bucket")
+				}
+			}
+			b.ReportMetric(float64(size.tx*16), "entries/snapshot")
+		})
+	}
+}

--- a/cmd/server/repeater_snapshot_1908_test.go
+++ b/cmd/server/repeater_snapshot_1908_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"runtime"
 	"testing"
 	"time"
 )
@@ -69,25 +68,43 @@ func TestRelayComputeConcurrentEviction1908(t *testing.T) {
 	store := relaySnapshotStore1908(30000, 256, 1)
 	key := fmt.Sprintf("%064x", 0)
 	want := len(store.byPathHop[key])
-	result := make(chan map[string]RepeaterRelayInfo, 1)
-	go func() { result <- store.computeRepeaterRelayInfoMap(24) }()
+	const readers = 2
+	start := make(chan struct{})
+	result := make(chan map[string]RepeaterRelayInfo, readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			<-start
+			result <- store.computeRepeaterRelayInfoMap(24)
+		}()
+	}
+	evicted := make(chan int, 1)
+	go func() {
+		<-start
+		evicted <- store.RunEviction()
+	}()
+	close(start)
 
-	// Observe the actual reader holding RLock, then queue eviction behind it.
-	// Eviction and the unlocked aggregation must safely use separate buckets.
-	deadline := time.Now().Add(5 * time.Second)
-	for store.mu.TryLock() {
-		store.mu.Unlock()
-		if time.Now().After(deadline) {
-			t.Fatal("relay computation did not acquire the snapshot lock")
+	// Either lock order is valid, including on a single CPU. The separate
+	// snapshot-preservation test deterministically checks bucket ownership;
+	// this exercises real concurrent callers without assuming a scheduler order.
+	deadline := time.After(30 * time.Second)
+	select {
+	case got := <-evicted:
+		if got != 1 {
+			t.Fatalf("evicted %d transmissions, want 1", got)
 		}
-		runtime.Gosched()
+	case <-deadline:
+		t.Fatal("eviction did not finish")
 	}
-	if got := store.RunEviction(); got != 1 {
-		t.Fatalf("evicted %d transmissions, want 1", got)
-	}
-	got := <-result
-	if got[key].RelayCount24h != want {
-		t.Errorf("in-flight relay snapshot count = %d, want %d", got[key].RelayCount24h, want)
+	for i := 0; i < readers; i++ {
+		select {
+		case got := <-result:
+			if count := got[key].RelayCount24h; count != want && count != want-1 {
+				t.Errorf("relay snapshot count = %d, want before-eviction %d or after-eviction %d", count, want, want-1)
+			}
+		case <-deadline:
+			t.Fatal("relay computation did not finish")
+		}
 	}
 }
 

--- a/cmd/server/store.go
+++ b/cmd/server/store.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"math"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -3279,7 +3280,7 @@ func (s *PacketStore) IngestNewObservations(sinceObsID, limit int) []map[string]
 				tx.parsedPath, tx.pathParsed = saved, savedFlag
 			}
 			// Remove old path-hop index entries using old hops.
-			// Resolved pubkey entries are managed via resolvedPubkeyIndex, not byPathHop.
+			// Resolved pubkeys remain indexed independently of the best raw path.
 			if len(oldHops) > 0 {
 				saved, savedFlag := tx.parsedPath, tx.pathParsed
 				tx.parsedPath, tx.pathParsed = oldHops, true
@@ -4114,11 +4115,9 @@ func (s *PacketStore) buildPathHopIndex() {
 // resolved relay attribution, leaving relay counts and transported scopes
 // empty after each cold load until live ingestion refilled them (#1904).
 //
-// Only transmissions still in s.packets are carried over. This matters:
-// eviction's removeTxFromPathHopIndex strips raw hops only (it derives them
-// from txGetParsedPath), so evicted transmissions linger in prev under their
-// resolved keys. Filtering them here is what keeps the index bounded by the
-// eviction policy instead of turning that gap into a permanent leak.
+// Only transmissions still in s.packets are carried over. Eviction also
+// prunes raw and resolved keys (#1908); this membership check prevents a
+// rebuild from reintroducing stale entries from the previous index.
 //
 // Cost is O(entries in prev) with one reused scratch map, and it runs only
 // where buildPathHopIndex already runs — cold load and background-fill
@@ -4264,7 +4263,7 @@ func relayMetrics(times []int64, now int64) (count1h, count24h int, lastRelayed 
 }
 
 // removeTxFromPathHopIndex removes a transmission from all its raw path-hop index entries.
-// Resolved pubkey entries are cleaned up via removeFromResolvedPubkeyIndex.
+// Used when the best raw path changes; eviction filters all keys in one batch.
 func removeTxFromPathHopIndex(idx map[string][]*StoreTx, tx *StoreTx) {
 	hops := txGetParsedPath(tx)
 	if len(hops) == 0 {
@@ -4814,8 +4813,22 @@ func (s *PacketStore) evictStaleInternal(rpBatch map[int][]string) int {
 
 		// Remove from subpath index
 		removeTxFromSubpathIndexFull(s.spIndex, s.spTxIndex, tx)
-		// Remove from path-hop index
-		removeTxFromPathHopIndex(s.byPathHop, tx)
+	}
+	// Sweep raw AND resolved hop keys once per batch (#1908). The hash-only
+	// membership index cannot recover full pubkey strings. Reuse the evicted
+	// ID set for O(total path-hop entries) work, with no per-tx string storage
+	// or repeated scans of shared buckets. DeleteFunc clears discarded pointer
+	// slots so backing arrays cannot keep evicted transmissions alive.
+	for key, list := range s.byPathHop {
+		filtered := slices.DeleteFunc(list, func(tx *StoreTx) bool {
+			_, evicted := evictedTxIDs[tx.ID]
+			return evicted
+		})
+		if len(filtered) == 0 {
+			delete(s.byPathHop, key)
+		} else {
+			s.byPathHop[key] = filtered
+		}
 	}
 	s.invalidateRelayStatsCache()
 


### PR DESCRIPTION
Eviction removes raw wire hops but leaves resolved full-key entries in `byPathHop`, retaining expired transmissions and stale relay counts/scopes. Filter every hop bucket once per eviction batch using the existing evicted-ID set, remove duplicate references and empty buckets, and clear discarded pointer slots.

Bulk relay aggregation now owns its bucket snapshots before releasing the read lock, so eviction and raw-path updates cannot mutate an in-flight reader. Three existing handler test fixtures also wait for index readiness or explicitly simulate not-ready state, preserving their original 200/503 assertions.

Fixes #1908.

Validation:

- Regression commits fail before their corresponding fixes: resolved keys/counts/scopes remain after eviction, and saved relay snapshots change during eviction.
- Targeted eviction, relay, scope, cache and concurrent-reader checks pass under `-race`; coverage includes time/cap eviction, missing resolved-path prefetch, disabled membership indexing, duplicate references, retained backing arrays and surviving entries.
- Local browser smoke: nodes, node details/path attribution and analytics render using the fixture-backed Go server.
- The last full Windows server race run, before the final snapshot-copy correction, had one remaining DB-only timing failure (`TestGetChannelMessagesPerfLargeChannel`: 2.198s against a 1.5s budget). The final correction was checked with focused race tests. The unchanged ingestor suite also cannot create one symlink without Windows privileges. These thresholds/assertions were preserved; full Linux Go/E2E results still require upstream CI approval.

Performance tradeoff: cleanup is O(total indexed pointers) per nonempty eviction batch, under the existing write lock. The minute-based ticker pays for one sweep instead of repeated scans of shared raw buckets. No per-transmission string index or dependency is added. Synthetic benchmark medians (three single-iteration runs, shared Windows host):

| Transmissions | Evicted | Before | After |
|---:|---:|---:|---:|
| 30,000 | 1 | 1.07 ms | 14.19 ms |
| 30,000 | 3,000 | 56.27 ms | 61.68 ms |
| 30,000 | 7,500 | 83.58 ms | 65.54 ms |
| 100,000 | 1 | 0.30 ms | 56.95 ms |
| 100,000 | 10,000 | 949.93 ms | 190.71 ms |
| 100,000 | 25,000 | 1,834.48 ms | 320.38 ms |

Fixture: eight raw plus eight resolved hops per transmission, two observations, 2,048 relays; 480,000/1,600,000 hop entries. Timing includes acquiring the store lock and omits unrelated secondary indexes. Small batches now pay for the complete sweep; shared-host timing is noisy.

Owning the bulk reader's arrays also has a measured cost on cold/bulk recomputation, rather than cached hits. Snapshot medians from three samples of ten iterations:

| Transmissions / relay nodes | Before time / bytes per operation | After time / bytes per operation |
|---|---:|---:|
| 30,000 / 50 | 0.0068 ms / 5,416 B | 23.65 ms / 4,101,435 B |
| 30,000 / 2,000 | 0.1374 ms / 196,768 B | 26.77 ms / 4,274,336 B |
| 100,000 / 2,000 | 0.1376 ms / 196,768 B | 27.89 ms / 13,959,337 B |

These are total snapshot costs, comparing the unsafe header-only snapshot with owned pointer arrays. Cleanup guarantees here apply to `byPathHop`; other indexes and existing periodic bulk-cache freshness are outside this change.

Following #1922, this runtime fix is separate from the release-routing and frontend-runner PRs. Current Go and E2E job results should be assessed separately from workflow-approval or staging-runner state.
