### PR TITLE
fix(nodes): dispose map timers with their owning view

### DIFF
--- a/public/nodes.js
+++ b/public/nodes.js
@@ -86,7 +86,9 @@
   let detailMap = null;
   let detailMapResizeTimer = null;
 
-  function removeDetailMap() {
+  function removeDetailMap(owner) {
+    // Async responses may still hold a detached view while another map is active.
+    if (owner && detailMap && !owner.contains(detailMap.getContainer())) return;
     clearTimeout(detailMapResizeTimer);
     detailMapResizeTimer = null;
     if (detailMap) { detailMap.remove(); detailMap = null; }
@@ -645,7 +647,7 @@
       const dupKeys = n.name && dupMap[n.name.toLowerCase()] ? dupMap[n.name.toLowerCase()].filter(function(k) { return k !== n.public_key; }) : [];
       const dupSection = dupKeys.length ? '<div class="dup-also-known" style="font-size:11px;color:var(--text-muted);margin-top:4px">Also known as: ' + dupKeys.map(function(k) { return '<a href="#/nodes/' + encodeURIComponent(k) + '" class="mono" style="font-size:11px">' + escapeHtml(k.slice(0, 12)) + '…</a>'; }).join(', ') + '</div>' : '';
 
-      removeDetailMap();
+      removeDetailMap(body);
       body.innerHTML = `
         <div class="node-full-card" style="padding:12px 16px;margin-bottom:8px">
           <div class="node-detail-name" style="font-size:20px">${escapeHtml(n.name || '(unnamed)')}${dupBadge}</div>
@@ -1026,7 +1028,7 @@
       const detail = is404
         ? 'No node matched the requested public key on this instance. It may exist on another deployment, or it may have been evicted/blacklisted here.'
         : 'The node detail API call failed: ' + escapeHtml(msg);
-      removeDetailMap();
+      removeDetailMap(body);
       body.innerHTML =
         '<div class="node-full-card" style="padding:24px;margin:16px auto;max-width:560px;text-align:center">' +
           '<div style="font-size:18px;font-weight:600;margin-bottom:8px">' + headline + '</div>' +
@@ -1613,8 +1615,10 @@
 
     try {
       const data = await fetchNodeDetail(pubkey);
+      if (selectedKey !== pubkey || !panel.isConnected) return;
       renderDetail(panel, data);
     } catch (e) {
+      if (selectedKey !== pubkey || !panel.isConnected) return;
       panel.innerHTML = `<div class="text-muted">Error: ${e.message}</div>`;
     }
   }
@@ -1639,7 +1643,7 @@
     const dupMap = buildDupNameMap(_allNodes);
     const dupBadge = dupNameBadge(n.name, n.public_key, dupMap);
 
-    removeDetailMap();
+    removeDetailMap(panel);
     panel.innerHTML = `
       <button class="panel-close-btn" title="Close detail pane (Esc)"><svg class="ph-icon" aria-hidden="true"><use href="/icons/phosphor-sprite.svg#ph-x"/></svg></button>
       <div class="node-detail">

--- a/public/nodes.js
+++ b/public/nodes.js
@@ -84,6 +84,21 @@
   let statusFilter = localStorage.getItem('meshcore-nodes-status-filter') || 'all';
   let wsHandler = null;
   let detailMap = null;
+  let detailMapResizeTimer = null;
+
+  function removeDetailMap() {
+    clearTimeout(detailMapResizeTimer);
+    detailMapResizeTimer = null;
+    if (detailMap) { detailMap.remove(); detailMap = null; }
+  }
+
+  function resizeDetailMapAfterLayout() {
+    const map = detailMap;
+    detailMapResizeTimer = setTimeout(() => {
+      detailMapResizeTimer = null;
+      map.invalidateSize();
+    }, 100);
+  }
 
   // #1461 followup: node-detail inset map tile layer that honors the
   // customizer dark-tile-provider pick (#1420/#1430). Falls back to
@@ -630,6 +645,7 @@
       const dupKeys = n.name && dupMap[n.name.toLowerCase()] ? dupMap[n.name.toLowerCase()].filter(function(k) { return k !== n.public_key; }) : [];
       const dupSection = dupKeys.length ? '<div class="dup-also-known" style="font-size:11px;color:var(--text-muted);margin-top:4px">Also known as: ' + dupKeys.map(function(k) { return '<a href="#/nodes/' + encodeURIComponent(k) + '" class="mono" style="font-size:11px">' + escapeHtml(k.slice(0, 12)) + '…</a>'; }).join(', ') + '</div>' : '';
 
+      removeDetailMap();
       body.innerHTML = `
         <div class="node-full-card" style="padding:12px 16px;margin-bottom:8px">
           <div class="node-detail-name" style="font-size:20px">${escapeHtml(n.name || '(unnamed)')}${dupBadge}</div>
@@ -787,11 +803,10 @@
       // Map
       if (hasLoc) {
         try {
-          if (detailMap) { detailMap.remove(); detailMap = null; }
           detailMap = L.map('nodeFullMap', { zoomControl: true, attributionControl: false }).setView([n.lat, n.lon], 13);
           _applyTilesToNodeMap(detailMap);
           L.marker([n.lat, n.lon]).addTo(detailMap).bindPopup(escapeHtml(n.name || n.public_key.slice(0, 12)));
-          setTimeout(() => detailMap.invalidateSize(), 100);
+          resizeDetailMapAfterLayout();
         } catch {}
       }
 
@@ -1011,6 +1026,7 @@
       const detail = is404
         ? 'No node matched the requested public key on this instance. It may exist on another deployment, or it may have been evicted/blacklisted here.'
         : 'The node detail API call failed: ' + escapeHtml(msg);
+      removeDetailMap();
       body.innerHTML =
         '<div class="node-full-card" style="padding:24px;margin:16px auto;max-width:560px;text-align:center">' +
           '<div style="font-size:18px;font-weight:600;margin-bottom:8px">' + headline + '</div>' +
@@ -1035,7 +1051,7 @@
   function destroy() {
     if (wsHandler) offWS(wsHandler);
     wsHandler = null;
-    if (detailMap) { detailMap.remove(); detailMap = null; }
+    removeDetailMap();
     if (regionChangeHandler) RegionFilter.offChange(regionChangeHandler);
     regionChangeHandler = null;
     nodes = [];
@@ -1413,6 +1429,7 @@
       if (e.key === 'Escape') {
         const panel = document.getElementById('nodesRight');
         if (panel && !panel.classList.contains('empty')) {
+          removeDetailMap();
           panel.classList.add('empty');
           panel.innerHTML = '<span>Select a node to view details</span>';
           selectedKey = null;
@@ -1439,6 +1456,7 @@
       }
       if (e.target.closest('.panel-close-btn')) {
         const panel = document.getElementById('nodesRight');
+        removeDetailMap();
         panel.classList.add('empty');
         panel.innerHTML = '<span>Select a node to view details</span>';
         selectedKey = null;
@@ -1590,6 +1608,7 @@
     renderRows();
     const panel = document.getElementById('nodesRight');
     panel.classList.remove('empty');
+    removeDetailMap();
     panel.innerHTML = '<div class="text-center text-muted" style="padding:40px">Loading…</div>';
 
     try {
@@ -1620,6 +1639,7 @@
     const dupMap = buildDupNameMap(_allNodes);
     const dupBadge = dupNameBadge(n.name, n.public_key, dupMap);
 
+    removeDetailMap();
     panel.innerHTML = `
       <button class="panel-close-btn" title="Close detail pane (Esc)"><svg class="ph-icon" aria-hidden="true"><use href="/icons/phosphor-sprite.svg#ph-x"/></svg></button>
       <div class="node-detail">
@@ -1711,11 +1731,10 @@
     // Init map
     if (hasLoc) {
       try {
-        if (detailMap) { detailMap.remove(); detailMap = null; }
         detailMap = L.map('nodeMap', { zoomControl: false, attributionControl: false }).setView([n.lat, n.lon], 13);
         _applyTilesToNodeMap(detailMap);
         L.marker([n.lat, n.lon]).addTo(detailMap).bindPopup(escapeHtml(n.name || n.public_key.slice(0, 12)));
-        setTimeout(() => detailMap.invalidateSize(), 100);
+        resizeDetailMapAfterLayout();
       } catch {}
     }
 

--- a/test-issue-1206-resize-observer-leak-e2e.js
+++ b/test-issue-1206-resize-observer-leak-e2e.js
@@ -47,7 +47,7 @@ const mapNodes = [
   { public_key: 'c3'.repeat(32), name: 'No location fixture', lat: null, lon: null },
 ].map((node) => ({ ...node, role: 'repeater', advert_count: 1 }));
 
-async function withNodeMaps(browser, fn) {
+async function withNodeMaps(browser, fn, allowedErrors = []) {
   const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
   const page = await ctx.newPage();
   page.setDefaultTimeout(8000);
@@ -67,7 +67,7 @@ async function withNodeMaps(browser, fn) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
     });
     await page.clock.install({ time: new Date('2026-01-01T00:00:00Z') });
-    await page.goto(BASE + '/#/nodes', { waitUntil: 'load' });
+    await page.goto(BASE + '/#/nodes', { waitUntil: 'domcontentloaded', timeout: 30000 });
     await page.locator('#nodesBody tr[data-key="' + mapNodes[0].public_key + '"]').waitFor();
     await page.clock.pauseAt(new Date('2026-01-01T00:02:00Z'));
     // Observe real Leaflet instances through public lifecycle APIs. No app hooks.
@@ -97,7 +97,8 @@ async function withNodeMaps(browser, fn) {
       if (node.lat != null) await page.locator(root + ' .leaflet-map-pane').waitFor({ state: 'attached' });
     };
     await fn(page, open);
-    assert(errors.length === 0, 'unexpected pageerror: ' + errors.join('; '));
+    const unexpectedErrors = errors.filter((error) => !allowedErrors.includes(error));
+    assert(unexpectedErrors.length === 0, 'unexpected pageerror: ' + unexpectedErrors.join('; '));
   } finally {
     await ctx.close();
   }
@@ -245,6 +246,57 @@ async function advanceMapClock(page, ms) {
     assert(maps[0].resizes.length === 0, 'no-location replacement must cancel the old resize');
     assert(await page.locator('#nodeMap').count() === 0, 'no-location node must not create a map');
   }));
+
+  for (const scenario of [
+    { view: 'full', fails: true },
+    { view: 'full', fails: false },
+    { view: 'side', fails: true },
+    { view: 'side', fails: false },
+  ]) {
+    const expectedError = scenario.fails ? 'API 500: /nodes/' + mapNodes[0].public_key : null;
+    await step(scenario.view + ' node map: stale ' + (scenario.fails ? 'failure' : 'no-location response') + ' preserves the replacement',
+      () => withNodeMaps(browser, async (page, open) => {
+        const requestUrl = '**/api/nodes/' + mapNodes[0].public_key;
+        let releaseResponse;
+        const holdResponse = new Promise((resolve) => { releaseResponse = resolve; });
+        await page.route(requestUrl, async (route) => {
+          await holdResponse;
+          await route.fulfill({ status: scenario.fails ? 500 : 200, contentType: 'application/json', body: JSON.stringify({
+            node: { ...mapNodes[0], lat: null, lon: null }, recentAdverts: [],
+          }) });
+        });
+        const requested = page.waitForRequest(requestUrl);
+        if (scenario.view === 'full') {
+          await page.evaluate((key) => { location.hash = '#/nodes/' + key; }, mapNodes[0].public_key);
+        } else {
+          await page.locator('#nodesBody tr[data-key="' + mapNodes[0].public_key + '"]').click();
+        }
+        await requested;
+        // Join the existing in-flight API promise so assertions run after the
+        // client has decoded/rejected the held response, not merely sent it.
+        const requestCompleted = page.evaluate((key) => api('/nodes/' + key).then(() => null, (error) => error.message), mapNodes[0].public_key);
+        await open(scenario.view, mapNodes[1]);
+        await advanceMapClock(page, 50);
+        // api() may report its rejected finally() derivative as a pageerror.
+        // Only this deliberately injected API failure is allowed by the helper.
+        releaseResponse();
+        let requestTimeout;
+        const result = await Promise.race([
+          requestCompleted,
+          new Promise((_, reject) => {
+            requestTimeout = setTimeout(() => reject(new Error('held response was not handled')), 8000);
+          }),
+        ]).finally(() => clearTimeout(requestTimeout));
+        assert(result === expectedError, 'held response must complete with the intended result');
+        let maps = await page.evaluate(() => window.__nodeMaps);
+        assert(maps.length === 1 && !maps[0].removed, 'stale response must not remove the replacement map');
+        assert(maps[0].resizes.length === 0, 'replacement must wait for its own resize deadline');
+        await advanceMapClock(page, 50);
+        maps = await page.evaluate(() => window.__nodeMaps);
+        assert(maps[0].resizes.length === 1 && maps[0].resizes[0].connected && !maps[0].resizes[0].removed,
+          'replacement must remain connected and receive its own resize');
+      }, expectedError ? [expectedError] : []));
+  }
 
   await browser.close();
   console.log('\nSPA observer and node-map lifecycle: ' + passed + ' passed, ' + failed + ' failed');

--- a/test-issue-1206-resize-observer-leak-e2e.js
+++ b/test-issue-1206-resize-observer-leak-e2e.js
@@ -12,6 +12,9 @@
  * outstanding (constructed but not disconnected) observers and assert it
  * does NOT grow with each /live mount.
  *
+ * Also exercises node-map disposal with a paused browser clock: navigation,
+ * pane closure and replacement must cancel the old map's delayed resize.
+ *
  * Run: BASE_URL=http://localhost:13581 node test-issue-1206-resize-observer-leak-e2e.js
  */
 'use strict';
@@ -29,6 +32,75 @@ function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
 async function gotoHash(page, hash) {
   await page.evaluate((h) => { window.location.hash = h; }, hash);
   await page.waitForTimeout(150);
+}
+
+// Synthetic nodes keep map lifecycle coverage independent of fixture locations.
+const mapNodes = [
+  { public_key: 'a1'.repeat(32), name: 'Map fixture A', lat: 0, lon: 0 },
+  { public_key: 'b2'.repeat(32), name: 'Map fixture B', lat: 1, lon: 1 },
+  { public_key: 'c3'.repeat(32), name: 'No location fixture', lat: null, lon: null },
+].map((node) => ({ ...node, role: 'repeater', advert_count: 1 }));
+
+async function withNodeMaps(browser, fn) {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  const page = await ctx.newPage();
+  page.setDefaultTimeout(8000);
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  try {
+    await page.route('**/api/nodes**', (route) => {
+      const path = new URL(route.request().url()).pathname;
+      const node = mapNodes.find((n) => path === '/api/nodes/' + n.public_key);
+      const body = path === '/api/nodes'
+        ? { nodes: mapNodes, total: mapNodes.length, counts: { repeater: mapNodes.length } }
+        : node ? { node, recentAdverts: [] }
+        : path === '/api/nodes/clock-skew' ? []
+        : /\/health$/.test(path) ? { stats: {}, observers: [], recentPackets: [] }
+        : /\/neighbors$/.test(path) ? { neighbors: [] }
+        : /\/paths$/.test(path) ? { paths: [] } : {};
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    });
+    await page.clock.install({ time: new Date('2026-01-01T00:00:00Z') });
+    await page.goto(BASE + '/#/nodes', { waitUntil: 'load' });
+    await page.locator('#nodesBody tr[data-key="' + mapNodes[0].public_key + '"]').waitFor();
+    await page.clock.pauseAt(new Date('2026-01-01T00:02:00Z'));
+    // Observe real Leaflet instances through public lifecycle APIs. No app hooks.
+    await page.evaluate(() => {
+      window.__nodeMaps = [];
+      L.Map.addInitHook(function() {
+        const container = this.getContainer();
+        if (container.id !== 'nodeMap' && container.id !== 'nodeFullMap') return;
+        const record = { removed: false, resizes: [] };
+        window.__nodeMaps.push(record);
+        this.on('unload', () => { record.removed = true; });
+        const invalidateSize = this.invalidateSize;
+        this.invalidateSize = function(...args) {
+          record.resizes.push({ removed: record.removed, connected: container.isConnected });
+          return invalidateSize.apply(this, args);
+        };
+      });
+    });
+    const open = async (view, node) => {
+      if (view === 'side') {
+        await page.locator('#nodesBody tr[data-key="' + node.public_key + '"]').click();
+      } else {
+        await page.evaluate((key) => { location.hash = '#/nodes/' + key; }, node.public_key);
+      }
+      const root = view === 'side' ? '#nodesRight' : '#nodeFullBody';
+      await page.locator(root + ' .node-detail-name').filter({ hasText: node.name }).waitFor();
+      if (node.lat != null) await page.locator(root + ' .leaflet-map-pane').waitFor({ state: 'attached' });
+    };
+    await fn(page, open);
+    assert(errors.length === 0, 'unexpected pageerror: ' + errors.join('; '));
+  } finally {
+    await ctx.close();
+  }
+}
+
+async function advanceMapClock(page, ms) {
+  // Playwright also reports exceptions from fake-timer callbacks via runFor.
+  const error = await page.clock.runFor(ms).then(() => null, (error) => error);
+  assert(!error, 'timer callback must not throw: ' + (error && error.message));
 }
 
 (async () => {
@@ -117,7 +189,60 @@ async function gotoHash(page, hash) {
   });
 
   await ctx.close();
+
+  for (const view of ['side', 'full']) {
+    await step(view + ' node map: navigation cancels the pending resize', () => withNodeMaps(browser, async (page, open) => {
+      await open(view, mapNodes[0]);
+      await page.evaluate(() => { location.hash = '#/live'; });
+      await page.locator('#vcrBar').waitFor();
+      await advanceMapClock(page, 100);
+      const maps = await page.evaluate(() => window.__nodeMaps);
+      assert(maps.length === 1 && maps[0].removed, 'navigation must remove the node map');
+      assert(maps[0].resizes.length === 0, 'removed map must not be resized');
+    }));
+
+    await step(view + ' node map: replacement only resizes at its own deadline', () => withNodeMaps(browser, async (page, open) => {
+      await open(view, mapNodes[0]);
+      await advanceMapClock(page, 50);
+      await open(view, mapNodes[1]);
+      await advanceMapClock(page, 50); // First map's deadline; replacement is only 50ms old.
+      let maps = await page.evaluate(() => window.__nodeMaps);
+      assert(maps.length === 2 && maps[0].removed && !maps[1].removed, 'replacement must own the surviving map');
+      assert(maps[0].resizes.length === 0 && maps[1].resizes.length === 0, 'old timer must not resize either map');
+      await advanceMapClock(page, 49);
+      maps = await page.evaluate(() => window.__nodeMaps);
+      assert(maps[1].resizes.length === 0, 'replacement must wait its full 100ms');
+      await advanceMapClock(page, 1);
+      maps = await page.evaluate(() => window.__nodeMaps);
+      assert(maps[1].resizes.length === 1 && !maps[1].resizes[0].removed && maps[1].resizes[0].connected,
+        'surviving map must resize once while connected');
+    }));
+  }
+
+  for (const close of ['button', 'Escape']) {
+    await step('side node map: ' + close + ' disposes the map before resize', () => withNodeMaps(browser, async (page, open) => {
+      await open('side', mapNodes[0]);
+      if (close === 'button') await page.locator('#nodesRight .panel-close-btn').click();
+      else await page.keyboard.press('Escape');
+      await page.locator('#nodesRight.empty').waitFor();
+      await advanceMapClock(page, 100);
+      const maps = await page.evaluate(() => window.__nodeMaps);
+      assert(maps.length === 1 && maps[0].removed, 'closing the pane must remove its map');
+      assert(maps[0].resizes.length === 0, 'closed pane map must not be resized');
+    }));
+  }
+
+  await step('side node map: no-location replacement disposes the pending map', () => withNodeMaps(browser, async (page, open) => {
+    await open('side', mapNodes[0]);
+    await open('side', mapNodes[2]);
+    await advanceMapClock(page, 100);
+    const maps = await page.evaluate(() => window.__nodeMaps);
+    assert(maps.length === 1 && maps[0].removed, 'no-location replacement must remove the previous map');
+    assert(maps[0].resizes.length === 0, 'no-location replacement must cancel the old resize');
+    assert(await page.locator('#nodeMap').count() === 0, 'no-location node must not create a map');
+  }));
+
   await browser.close();
-  console.log('\n#1206 ResizeObserver leak: ' + passed + ' passed, ' + failed + ' failed');
+  console.log('\nSPA observer and node-map lifecycle: ' + passed + ' passed, ' + failed + ' failed');
   process.exit(failed ? 1 : 0);
 })().catch((e) => { console.error(e); process.exit(1); });

--- a/test-issue-1206-resize-observer-leak-e2e.js
+++ b/test-issue-1206-resize-observer-leak-e2e.js
@@ -31,7 +31,13 @@ function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
 
 async function gotoHash(page, hash) {
   await page.evaluate((h) => { window.location.hash = h; }, hash);
-  await page.waitForTimeout(150);
+  if (hash === '#/live') await waitForVCRTracker(page);
+  else await page.locator('#nodesLeft[data-loaded="true"]').waitFor();
+}
+
+async function waitForVCRTracker(page) {
+  // The tracker publishes this only after live's async node loading finishes.
+  await page.locator('.live-page[style*="--vcr-bar-height"]').waitFor({ state: 'attached' });
 }
 
 // Synthetic nodes keep map lifecycle coverage independent of fixture locations.
@@ -150,7 +156,7 @@ async function advanceMapClock(page, ms) {
   await step('initial /#/live mount constructs at most 1 VCR ResizeObserver', async () => {
     await page.goto(BASE + '/#/live', { waitUntil: 'domcontentloaded' });
     await page.waitForSelector('#vcrBar', { timeout: 8000 });
-    await page.waitForTimeout(300);
+    await waitForVCRTracker(page);
     // Baseline snapshot — record outstanding right after first /live mount.
     const snap = await page.evaluate(() => ({
       outstanding: window.__roOutstanding,
@@ -165,10 +171,8 @@ async function advanceMapClock(page, ms) {
   await step('3 SPA round-trips /live<->/nodes do NOT grow outstanding observer count', async () => {
     for (let i = 0; i < 3; i++) {
       await gotoHash(page, '#/nodes');
-      await page.waitForTimeout(150);
       await gotoHash(page, '#/live');
       await page.waitForSelector('#vcrBar', { timeout: 8000 });
-      await page.waitForTimeout(200);
     }
     const after = await page.evaluate(() => ({
       outstanding: window.__roOutstanding,


### PR DESCRIPTION
Red commit: `2f1a50e` (local Chromium: 2 passed, 7 assertion failures). Ownership regression: `059ab49` (9 passed, 4 assertion failures). CI: [run](https://github.com/Kpa-clawbot/CoreScope/actions/runs/33988139479) awaits maintainer approval (`action_required`); 0 jobs started.

Rapid navigation or closing node detail could leave a delayed resize targeting a removed or replacement map. Disposal now cancels its timer, each resize captures its own map, and delayed responses respect the view owning the current map. Stale side-pane responses are ignored before rendering.

Fixes #1972.

- E2E assertion added: `test-issue-1206-resize-observer-leak-e2e.js:216` and `:292`. This existing CI-selected suite covers navigation, replacement deadlines, close/Escape, no-location rendering, and late error/success responses. Existing observer-growth assertions remain intact; readiness waits replace fixed sleeps.
- Browser verified: local fixture with real Chromium and Leaflet; 13 browser checks passed after push. Evidence: `data/node-map-validation/post-push-browser.log` and `data/node-map-validation/evidence.md`.
- Validation: frontend unit suites 99/18/666 passed; JavaScript syntax, CSS variables, whitespace, PII and XSS checks passed. Backend unchanged; Go suites not rerun.
- Independent adversarial, expert and TDD reviews found no required changes. Two original navigation checks initially timed out; the unchanged parent rerun passed 13/13 (`parent-browser-confirm.log`).
- Performance/config: one timer handle, no packet/node loops or new requests. Tests enforce zero stale invalidations and one resize at the surviving map's deadline. Existing 100ms delay retained; no new settings or throughput claim.

Fix commits: `2492a65`, `1dc090d`.

## Preflight overrides

- External `run-all.sh` is unavailable. Scoped branch, red/green, PII, CSS, XSS and whitespace checks were run directly; no migrations, SQL attribution or image markup are added.
