### PR TITLE
feat(scope-audit): count and surface the traffic this instance cannot name

### DIFF
--- a/cmd/server/scope_audit.go
+++ b/cmd/server/scope_audit.go
@@ -283,6 +283,20 @@ func normScope(s string) string {
 type scopeAuditTargetAgg struct {
 	scopes          map[string]*ScopeObservation
 	unscopedPackets int64
+	// unmatchedPackets counts packets this target was observed forwarding
+	// that carried a transport scope no configured region key matched
+	// (transmissions.scope_name = the empty string). Deliberately NOT folded
+	// into unscopedPackets: those two are opposites. Unscoped means the packet
+	// carried no scope at all (scope_name SQL NULL) and is what '*' governs;
+	// unmatched means it IS scoped and this instance simply holds no key for
+	// that region, so '*' says nothing about it. See scopeNameForDB in the
+	// ingestor for the encoding.
+	//
+	// A non-zero value is a caveat on this target's notObserved entries: any
+	// of them may be a region this instance cannot name rather than one the
+	// repeater is not forwarding.
+	unmatchedPackets int64
+
 	// ambiguousHops counts forwarder-hop observations in the window whose
 	// truncated hash prefix matched this target AND at least one other
 	// declared target — see ScopeAuditForwarding's doc comment for why
@@ -622,7 +636,14 @@ func (s *PacketStore) ScopeAuditForwarding(sinceISO string, targets []string) (m
 				continue
 			}
 			if scopeName.String == "" {
-				continue // unmatched — not part of the declared/observed comparison
+				// Unmatched: transport-scoped, but no configured region key
+				// matched code1. Still not part of the declared/observed
+				// comparison — it names no region, so it can never satisfy a
+				// declaration — but it is the evidence that a notObserved
+				// finding on this row may be a gap in this instance's
+				// hashRegions rather than in the repeater's forwarding.
+				agg.unmatchedPackets++
+				continue
 			}
 			name := normScope(scopeName.String)
 			so, ok := agg.scopes[name]
@@ -741,6 +762,21 @@ type ScopeAuditRow struct {
 	// UndeclaredObserved entry is unaffected by it (ambiguous hops are never
 	// attributed to a scope at all).
 	AmbiguousHops int64 `json:"ambiguousHops"`
+
+	// ObservedUnmatchedPackets counts packets this repeater was observed
+	// forwarding whose transport scope matched no region key this instance
+	// holds. Like AmbiguousHops it is a caveat rather than a finding, but the
+	// two have different causes and different fixes: AmbiguousHops is a
+	// pubkey-prefix collision between two repeaters and nobody's fault,
+	// ObservedUnmatchedPackets is a missing entry in this instance's own
+	// hashRegions and the reader can act on it. A non-zero value means any
+	// NotObserved entry on this row may name a region this instance cannot
+	// name rather than one the repeater is not forwarding.
+	//
+	// It says nothing about DeclaredWildcard: unmatched traffic IS scoped, so
+	// it never feeds WildcardContradiction, which counts only plain unscoped
+	// floods.
+	ObservedUnmatchedPackets int64 `json:"observedUnmatchedPackets"`
 }
 
 // ScopeAuditResponse is the payload for GET /api/scope-audit. Only
@@ -1057,26 +1093,28 @@ func (s *Server) computeScopeAudit(window, sinceISO string) (*ScopeAuditResponse
 			}
 		}
 
-		var unscopedPackets, ambiguousHops int64
+		var unscopedPackets, ambiguousHops, unmatchedPackets int64
 		if agg != nil {
 			unscopedPackets = agg.unscopedPackets
 			ambiguousHops = agg.ambiguousHops
+			unmatchedPackets = agg.unmatchedPackets
 		}
 
 		resp.Repeaters = append(resp.Repeaters, ScopeAuditRow{
-			PublicKey:               pk,
-			Name:                    id.Name,
-			Role:                    id.Role,
-			DeclaredRegions:         declaredNamed,
-			DeclaredWildcard:        declaredWildcard,
-			ConfigState:             scopeAuditConfigState(declaredNamed, declaredWildcard),
-			DeclaredAt:              d.ObservedAt,
-			Truncated:               d.Truncated,
-			NotObserved:             notObserved,
-			UndeclaredObserved:      undeclared,
-			ObservedUnscopedPackets: unscopedPackets,
-			WildcardContradiction:   unscopedPackets > 0 && !declaredWildcard,
-			AmbiguousHops:           ambiguousHops,
+			PublicKey:                pk,
+			Name:                     id.Name,
+			Role:                     id.Role,
+			DeclaredRegions:          declaredNamed,
+			DeclaredWildcard:         declaredWildcard,
+			ConfigState:              scopeAuditConfigState(declaredNamed, declaredWildcard),
+			DeclaredAt:               d.ObservedAt,
+			Truncated:                d.Truncated,
+			NotObserved:              notObserved,
+			UndeclaredObserved:       undeclared,
+			ObservedUnscopedPackets:  unscopedPackets,
+			WildcardContradiction:    unscopedPackets > 0 && !declaredWildcard,
+			AmbiguousHops:            ambiguousHops,
+			ObservedUnmatchedPackets: unmatchedPackets,
 		})
 	}
 

--- a/cmd/server/scope_audit_test.go
+++ b/cmd/server/scope_audit_test.go
@@ -1084,3 +1084,92 @@ func TestHandleScopeAuditServesSecondRequestFromCache(t *testing.T) {
 // keeps the '#' (hashRegions config), regions_csv arrives from the firmware
 // with it already stripped. Declared "be-van" and observed "#be-van" must be
 // recognised as the same scope, not reported as both missing and undeclared.
+
+// TestScopeAuditForwardingCountsUnmatchedPackets: a transport-scoped packet
+// whose code1 matched no configured region key is stored with scope_name = ""
+// (scopeNameForDB's "transport-scoped but unnameable" state). It is not a
+// named scope, so it must not enter agg.scopes, and it is not an unscoped
+// plain flood either, so it must not enter unscopedPackets. It is its own
+// fact: this instance saw the target forward traffic it holds no key for.
+//
+// Without this counter the audit reports the declared region as "not
+// observed", which reads as a finding about the repeater when it is really a
+// gap in this instance's own hashRegions.
+func TestScopeAuditForwardingCountsUnmatchedPackets(t *testing.T) {
+	s := newScopeTestStore(t)
+	hop := testFullPubkeyA[:4]
+	recent := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	seedTransmissionRouteAt(t, s, hop, scopeUnmatched(), RouteFlood, recent)
+
+	got, err := s.ScopeAuditForwarding("2026-01-01T00:00:00Z", []string{testFullPubkeyA})
+	if err != nil {
+		t.Fatal(err)
+	}
+	agg := got[testFullPubkeyA]
+	if agg == nil {
+		t.Fatalf("want an agg for the target, got none (result = %+v)", got)
+	}
+	if agg.unmatchedPackets != 1 {
+		t.Errorf("unmatchedPackets = %d, want 1", agg.unmatchedPackets)
+	}
+	if len(agg.scopes) != 0 {
+		t.Errorf("scopes = %+v, want empty — an unmatched packet names no region", agg.scopes)
+	}
+	if agg.unscopedPackets != 0 {
+		t.Errorf("unscopedPackets = %d, want 0 — unmatched is not the same as unscoped", agg.unscopedPackets)
+	}
+}
+
+// TestScopeAuditForwardingCountsUnmatchedOnMidPathHop is the post-M0 case that
+// carries almost all of this counter's real volume: before M0 only a last hop
+// was attributed, so a repeater deep in a flood path contributed nothing at
+// all. Now every hop counts, and the same de-duplication that protects the
+// named-scope tally must protect this one — a target appearing twice in one
+// path is still one packet, not two.
+func TestScopeAuditForwardingCountsUnmatchedOnMidPathHop(t *testing.T) {
+	s := newScopeTestStore(t)
+	hop := testFullPubkeyA[:4]
+	recent := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	seedTransmissionPathAt(t, s, []string{"AAAA", hop, "BBBB", hop}, scopeUnmatched(), RouteFlood, recent)
+
+	got, err := s.ScopeAuditForwarding("2026-01-01T00:00:00Z", []string{testFullPubkeyA})
+	if err != nil {
+		t.Fatal(err)
+	}
+	agg := got[testFullPubkeyA]
+	if agg == nil {
+		t.Fatalf("want an agg for the mid-path target, got none (result = %+v)", got)
+	}
+	if agg.unmatchedPackets != 1 {
+		t.Errorf("unmatchedPackets = %d, want 1 — one transmission, matched on two of its hops", agg.unmatchedPackets)
+	}
+}
+
+// TestHandleScopeAuditSurfacesUnmatchedPackets: a repeater declares "behss",
+// and this instance sees it forward transport-scoped traffic it cannot name.
+// The row must still list "behss" as notObserved — an unmatched packet names
+// no region, so it cannot satisfy the declaration — but it must also carry
+// observedUnmatchedPackets, so a client can say the finding might be a missing
+// region key rather than a silent repeater.
+func TestHandleScopeAuditSurfacesUnmatchedPackets(t *testing.T) {
+	srv, router := setupScopeAuditServer(t)
+	pk := testFullPubkeyA
+	insertDeclared(t, srv, pk, time.Now().UTC().Format(time.RFC3339), "behss", 0)
+	recent := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	seedTransmissionRouteAt(t, srv.store, pk[:4], scopeUnmatched(), RouteFlood, recent)
+
+	got := getScopeAudit(t, router, "")
+	if len(got.Repeaters) != 1 {
+		t.Fatalf("repeaters = %+v, want 1", got.Repeaters)
+	}
+	row := got.Repeaters[0]
+	if row.ObservedUnmatchedPackets != 1 {
+		t.Errorf("observedUnmatchedPackets = %d, want 1", row.ObservedUnmatchedPackets)
+	}
+	if len(row.NotObserved) != 1 || row.NotObserved[0] != "behss" {
+		t.Errorf("notObserved = %v, want [\"behss\"] — an unmatched packet names no region and cannot satisfy a declaration", row.NotObserved)
+	}
+	if row.WildcardContradiction {
+		t.Error("wildcardContradiction = true, want false — unmatched traffic is scoped, so it says nothing about '*'")
+	}
+}

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -40,6 +40,7 @@
 - [GET /api/analytics/hash-sizes](#get-apianalyticshash-sizes)
 - [GET /api/analytics/subpaths](#get-apianalyticssubpaths)
 - [GET /api/analytics/subpath-detail](#get-apianalyticssubpath-detail)
+- [GET /api/scope-audit](#get-apiscope-audit)
 - [GET /api/scope-stats](#get-apiscope-stats)
 - [GET /api/resolve-hops](#get-apiresolve-hops)
 - [GET /api/traces/:hash](#get-apitraceshash)
@@ -1567,6 +1568,137 @@ Detailed stats for a specific subpath.
   ]
 }
 ```
+
+---
+
+## GET /api/scope-audit
+
+Network-wide declared-vs-observed region-scope comparison: for every repeater that has
+ever successfully answered a declared-regions request, which of its declared regions have
+no observed forwarding in the window, which scopes it forwards without declaring, and
+whether it contradicts its own `'*'` wildcard. This is the whole-network answer to the
+question `GET /api/nodes/:pubkey/scopes` answers one repeater at a time — see that
+endpoint's notes for the full explanation of the three traps this comparison has to get
+right (the `#`-prefix spelling difference, `'*'` not being a scope, and "never asked"
+not being the same as "declared nothing"), which apply here identically.
+
+### Query Parameters
+
+| Param    | Type   | Default | Description                    |
+|----------|--------|---------|---------------------------------|
+| `window` | string | `24h`   | Time window: `1h`, `24h`, `7d` |
+
+### Response `200`
+
+```jsonc
+{
+  "window": string,                    // echoed window ("1h", "24h", or "7d")
+  "since":  string (ISO),              // start of the observed-forwarding window
+  "repeaters": [
+    {
+      "publicKey":        string,
+      "name":             string,      // "" if the node row is gone (pruned/deleted)
+      "role":             string,      // "" if unknown
+      "declaredRegions":  [string],    // '*' excluded — see declaredWildcard
+      "declaredWildcard": boolean,     // '*' present in the raw declared list
+      "configState":      string,      // "full" | "no-scopes" | "no-unscoped" | "no-flood" — see note below
+      "declaredAt":       string (ISO),// age of the DECLARED answer, not bounded by window
+      "truncated":        boolean,     // declared list may have had entries silently dropped
+
+      "notObserved":            [string],            // declared regions with zero matched-forwarding observed this window
+      "undeclaredObserved":     [
+        { "scope": string, "packets": number, "firstSeen": string (ISO), "lastSeen": string (ISO) }
+      ],
+      "observedUnscopedPackets": number,               // plain-FLOOD packets forwarded this window
+      "wildcardContradiction":   boolean,               // observed unscoped forwarding but '*' not declared
+      "ambiguousHops":            number,                // forwarder hops this window that could not be attributed — see note below
+      "observedUnmatchedPackets": number                 // forwarded packets whose scope this instance holds no key for — see note below
+    }
+  ]
+}
+```
+
+### Response `400`
+
+```json
+{ "error": "window must be 1h, 24h, or 7d" }
+```
+
+**Notes:**
+- Only repeaters with **at least one** declared-regions answer appear in `repeaters`. A
+  repeater that was never successfully asked is absent, not shown as a row that declares
+  nothing — those are different facts (see `GET /api/nodes/:pubkey/scopes`'s "never asked"
+  note).
+- `window` bounds `notObserved` / `undeclaredObserved` / `observedUnscopedPackets` only —
+  `declaredAt` is always the latest declared reading regardless of age, exactly like
+  `declared.observedAt` on the per-node endpoint. **A "declared but not observed" result
+  is weak evidence at `window=1h` (a quiet region can simply have had no traffic) and much
+  stronger at `window=7d`; a client MUST show which window a result belongs to and must
+  not present a `1h` result as if it were `7d`.** Because `declaredAt` is not bounded by
+  `window`, the declared answer and the forwarding evidence are not guaranteed to be
+  temporally aligned — a repeater could have declared its regions well before, or even
+  after, the window that produced `notObserved` — and the server makes no attempt to
+  align them; the `declaredAt` column in the UI is the mitigation (so a stale declared
+  answer is visible to the reader), not a guarantee that the two sides describe the same
+  period.
+- `ambiguousHops` counts forwarder-hop observations in this window whose truncated hash
+  prefix matched more than one declared target's pubkey — i.e. two or more repeaters that
+  declared a region list happen to share that prefix. Such a hop is attributed to **none**
+  of the matching targets (crediting all of them risks papering over a real gap in a
+  colliding neighbour's row; crediting none of them invents no failure) and this counter
+  is incremented on **every** matching target instead. A row with a non-zero
+  `ambiguousHops` carries weaker evidence than one with zero: any entry in that row's
+  `notObserved` could be explained by a prefix collision rather than a genuine absence of
+  forwarding, and a client should present it as a caveat rather than a confirmed finding.
+- `observedUnmatchedPackets` counts packets this repeater was observed forwarding whose
+  transport scope matched no region key this instance has configured (`hashRegions`), so
+  the ingestor stored them with an empty `scope_name`. Those packets name no region and
+  therefore cannot satisfy a declared one, which means **a repeater forwarding a region
+  this instance cannot name is reported exactly like one forwarding nothing**. A non-zero
+  value is a caveat on this row's `notObserved`, in the same spirit as `ambiguousHops` but
+  with a different cause and a different fix: `ambiguousHops` is a pubkey-prefix collision
+  between two repeaters and nobody's fault, `observedUnmatchedPackets` is a missing entry
+  in this instance's own configuration and the operator can act on it. It is **not**
+  evidence for or against `declaredWildcard` — unmatched traffic is scoped, so it never
+  affects `wildcardContradiction`, which counts only plain unscoped floods.
+- All scope names in `declaredRegions` / `notObserved` / `undeclaredObserved[].scope` are
+  already normalised (no leading `#`) — the server does the `#`/no-`#` reconciliation
+  described on the per-node endpoint so this response is directly comparable without a
+  client-side normalisation step.
+- `'*'` is never present in `declaredRegions`, `notObserved`, or `undeclaredObserved` — see
+  `declaredWildcard` and `wildcardContradiction` for its dedicated (non-scope) treatment,
+  same rule as the per-node endpoint.
+- `configState` is a derived reading of `declaredRegions`/`declaredWildcard` together —
+  the repeater's overall configuration shape, rather than a per-region detail:
+  - `"full"` — named regions **and** `'*'` declared: fully configured, forwards both its
+    declared regions and plain unscoped floods.
+  - `"no-scopes"` — `'*'` only, no named regions.
+  - `"no-unscoped"` — named regions declared, `'*'` absent: this repeater does **not**
+    forward plain unscoped floods. This reading is exact — `'*'` absent from the export
+    always means the wildcard denies flooding.
+  - `"no-flood"` — neither named regions nor `'*'`: the repeater answered, but nothing at
+    all is flood-allowed, not even plain unscoped traffic. The "no unscoped forwarding"
+    half of this is exact for the same reason as `"no-unscoped"`; the "no named regions"
+    half carries the same caveat as `"no-scopes"` below.
+
+  **Caveat on `"no-scopes"` and `"no-flood"`:** the firmware exports the FLOOD-*allowed*
+  set (`region_map.exportNamesTo(..., REGION_DENY_FLOOD)` in
+  `examples/simple_repeater/MyMesh.cpp`), not "every region this repeater has configured".
+  A repeater with regions defined but every one of them marked deny-flood exports exactly
+  the same list as a repeater with no region tree at all — the two are indistinguishable
+  from this data alone. In practice `"no-scopes"` is almost always "no scopes configured",
+  but a client MUST NOT present it as proven absence of configuration; word it as "no
+  region is flood-allowed" rather than "no regions exist".
+- `wildcardContradiction` is `true` when the repeater was observed forwarding unscoped
+  (plain-`FLOOD`) traffic this window but its declared list omits `'*'` — it declares it
+  will NOT forward those packets, and the traffic says otherwise.
+- Rows are sorted with the interesting cases first: most `notObserved` entries first, then
+  `wildcardContradiction`, then most `undeclaredObserved` entries, then alphabetically by
+  name. A repeater in full agreement (no `notObserved`, no `wildcardContradiction`, no
+  `undeclaredObserved`) sorts to the bottom.
+- Cached 30 seconds per window, mirroring `/api/scope-stats`.
+- Blacklisted nodes and nodes matching an operator-configured hidden-name prefix are
+  excluded, same as other multi-node endpoints.
 
 ---
 

--- a/public/scope-audit.css
+++ b/public/scope-audit.css
@@ -79,3 +79,8 @@
 .sa-empty { line-height: 1.6; max-width: 70ch; }
 .sa-empty ul { margin: 8px 0; padding-left: 20px; }
 .sa-empty li { margin: 4px 0; }
+
+/* Same muted, dashed treatment as .sa-chip-ambiguous on purpose: both are
+   caveats on the row's finding, not findings themselves, and neither may
+   compete visually with the red/green scope chips beside them. */
+.sa-chip-unmatched { background: var(--section-bg, var(--card-bg)); color: var(--text-muted); border: 1px dashed var(--border); font-family: inherit; font-style: italic; }

--- a/public/scope-audit.js
+++ b/public/scope-audit.js
@@ -183,6 +183,31 @@
       ' in this window matched more than one declared target\'s pubkey prefix and could not be attributed to any of them. Any “not observed” entry on this row may be explained by that prefix collision rather than a real gap.">possibly ambiguous</span>';
   }
 
+  // unmatchedCaveat flags rows where this instance saw the repeater forward
+  // transport-scoped traffic it holds no region key for. The ingestor stores
+  // those packets with an empty scope_name (see scopeNameForDB), so they name
+  // no region and can never satisfy a declared one — a repeater forwarding a
+  // region this instance cannot name looks exactly like one forwarding
+  // nothing.
+  //
+  // Distinct from ambiguousCaveat, and the distinction is the whole point:
+  // that one is a prefix collision between two repeaters and is nobody's
+  // fault, this one is a missing entry in this instance's own hashRegions and
+  // the reader can fix it. Saying so is what stops them investigating an
+  // innocent repeater.
+  //
+  // The count is server-supplied, so a non-numeric value renders nothing
+  // rather than the string "NaN forwarded packets".
+  function unmatchedCaveat(row) {
+    var n = row.observedUnmatchedPackets;
+    if (typeof n !== 'number' || !isFinite(n) || n <= 0) return '';
+    var label = escapeHtml(n) + ' forwarded packet' + (n === 1 ? '' : 's');
+    return ' <span class="sa-chip sa-chip-unmatched" title="' + label +
+      ' in this window carried a region scope this CoreScope instance holds no key for, so it could not be named. ' +
+      'Any &#39;not observed&#39; entry on this row may be a missing entry in this instance&#39;s hashRegions config rather than a repeater that is not forwarding.">' +
+      label + ' unnameable</span>';
+  }
+
   // statusScore ranks a row's Status column numerically for sorting — a
   // simple weighted count (notObserved dominates, matching the server's own
   // findings-first ranking) rather than the badge text, which the Status
@@ -210,7 +235,7 @@
       '<td class="sa-name" data-value="' + escapeHtml(nameSortValue) + '">' + nameHtml(row) + (row.role != null && row.role !== '' ? '<span class="text-muted sa-role"> ' + escapeHtml(row.role) + '</span>' : '') + '</td>' +
       '<td data-value="' + statusScore(row) + '">' + issuesHtml + '</td>' +
       '<td data-value="' + escapeHtml(CONFIG_STATES[row.configState].label) + '">' + configStateHtml(row) + '</td>' +
-      '<td data-value="' + row.notObserved.length + '">' + mergedScopeChips(row) + (row.declaredWildcard ? ' <span class="sa-chip sa-chip-wildcard" title="Declares the \'*\' wildcard — allows plain unscoped floods.">*</span>' : '') + ambiguousCaveat(row) + '</td>' +
+      '<td data-value="' + row.notObserved.length + '">' + mergedScopeChips(row) + (row.declaredWildcard ? ' <span class="sa-chip sa-chip-wildcard" title="Declares the \'*\' wildcard — allows plain unscoped floods.">*</span>' : '') + ambiguousCaveat(row) + unmatchedCaveat(row) + '</td>' +
       '<td data-value="' + (isNaN(declaredAtMs) ? '' : declaredAtMs) + '">' + ageHtml(row) + (row.truncated ? ' <span class="ns-truncated" title="Declared list was truncated by the repeater — a missing region here is not necessarily a real absence.">truncated</span>' : '') + '</td>' +
       '</tr>';
   }
@@ -360,7 +385,7 @@
     // Exposed so the helper tests can assert what the Scopes column RENDERS
     // rather than grepping this file, the same reason map.js exposes its label
     // builder (#1356/#1933).
-    window.__meshcoreScopeAuditInternals = { mergedScopeChips: mergedScopeChips, emptyStateHtml: emptyStateHtml, sourcesLineHtml: sourcesLineHtml };
+    window.__meshcoreScopeAuditInternals = { mergedScopeChips: mergedScopeChips, emptyStateHtml: emptyStateHtml, sourcesLineHtml: sourcesLineHtml, unmatchedCaveat: unmatchedCaveat };
   }
 
   registerPage('scope-audit', { init: init, destroy: destroy });

--- a/test-frontend-helpers.js
+++ b/test-frontend-helpers.js
@@ -7229,6 +7229,63 @@ console.log('\n=== scope-audit.js: mergedScopeChips ===');
   });
 }
 
+// ===== scope-audit.js: unmatchedCaveat =====
+// A declared region this instance holds no hashRegions key for can never turn
+// green, however much traffic the repeater forwards: the ingestor stores such
+// packets with an empty scope_name, so there is no name for the audit to match
+// the declaration against. On live data that explains a large share of all
+// notObserved entries, so the column must be able to say so instead of
+// presenting every grey chip as a confirmed gap.
+console.log('\n=== scope-audit.js: unmatchedCaveat ===');
+{
+  const ctx = makeSandbox();
+  ctx.registerPage = () => {};
+  loadInCtx(ctx, 'public/app.js');
+  loadInCtx(ctx, 'public/scope-audit.js');
+  const caveat = ctx.__meshcoreScopeAuditInternals.unmatchedCaveat;
+
+  test('zero unmatched packets renders nothing at all', () => {
+    assert.strictEqual(caveat({ observedUnmatchedPackets: 0 }), '');
+  });
+
+  test('a missing field renders nothing (older server, field absent)', () => {
+    assert.strictEqual(caveat({}), '');
+  });
+
+  test('a non-zero count renders a chip carrying the number', () => {
+    const h = caveat({ observedUnmatchedPackets: 148 });
+    assert.ok(h.includes('sa-chip-unmatched'), 'should carry its own class');
+    assert.ok(h.includes('148'), 'should state the count, not just that there is one');
+  });
+
+  test('singular and plural are both grammatical', () => {
+    assert.ok(caveat({ observedUnmatchedPackets: 1 }).includes('1 forwarded packet '));
+    assert.ok(caveat({ observedUnmatchedPackets: 2 }).includes('2 forwarded packets '));
+  });
+
+  test('the title names the cause, not just the symptom', () => {
+    // The operator fix is a hashRegions edit; a caveat that does not say so
+    // sends them looking at the repeater instead of at their own config.
+    const h = caveat({ observedUnmatchedPackets: 5 });
+    assert.ok(h.includes('hashRegions'), 'must name the config key that fixes it');
+  });
+
+  test('a non-numeric count renders nothing rather than NaN', () => {
+    // observedUnmatchedPackets is server-supplied. A truthiness check accepts
+    // a string, and the chip then reads "NaN forwarded packets".
+    assert.strictEqual(caveat({ observedUnmatchedPackets: '12' }), '');
+    assert.strictEqual(caveat({ observedUnmatchedPackets: NaN }), '');
+  });
+
+  test('the count is not injected raw into markup', () => {
+    // observedUnmatchedPackets is server-supplied. It is a number in every
+    // sane response, but the chip must not become an injection point if that
+    // ever stops holding.
+    const h = caveat({ observedUnmatchedPackets: '1"><script>alert(1)</script>' });
+    assert.ok(!h.includes('<script'), 'must not emit raw markup from a server-supplied value');
+  });
+}
+
 // The empty state is what a stock install sees: neither collector ships with
 // CoreScope, so most deployments open this page and find nothing. It therefore
 // has to explain where the data comes from, not just report its absence.


### PR DESCRIPTION
Follow-up to #1986, and the second half of the same problem.

`ScopeAuditForwarding` drops rows whose `scope_name` is the empty string with a bare `continue`. That empty string is the ingestor's "transport-scoped, but no configured region key matched `code1`" state (`scopeNameForDB`), so those packets name no region and can never satisfy a declared one. The consequence is on the page: **a repeater forwarding a region this instance holds no `hashRegions` key for is reported exactly like a repeater forwarding nothing at all.** The audit presents a gap in the reader's own configuration as a finding about someone else's hardware.

This counts them per target, exposes the count as `observedUnmatchedPackets`, and renders it as a caveat chip beside the scope chips.

## Why it is not a rare edge

Measured on a live instance before this landed: of 613 `notObserved` entries across 205 repeaters, **260 named a region that never appeared under any name in the whole 7-day window**. Two of them (`behss`, `fm-112`) were hash-verified as genuinely forwarded traffic the instance simply could not name: packet `0a065d41d51f1f77` decodes to `code1=9209`, which is exactly the code `#fm-112` derives over that packet's own payload.

That instance had 16 region keys configured against 124 distinct region names its repeaters declare. A stock install has fewer.

## What the counter is not

It is deliberately **not** folded into `unscopedPackets`. The two are opposites:

| | meaning | what governs it |
|---|---|---|
| `unscopedPackets` | the packet carried no scope at all (`scope_name` SQL NULL) | the `*` wildcard |
| `observedUnmatchedPackets` | the packet IS scoped, this instance holds no key for that region | nothing the repeater declares |

For the same reason the new count never feeds `wildcardContradiction`, which counts only plain unscoped floods. `scopeNameForDB` in the ingestor is the source of truth for that three-state encoding, and the comments point there rather than restating it.

It is also distinct from `ambiguousHops`, and the distinction is the point of the chip: that one is a pubkey-prefix collision between two repeaters and is nobody's fault, this one is a missing entry in the reader's own configuration and they can act on it. Saying which is which is what stops someone investigating an innocent repeater.

## Frontend

The chip reuses the muted dashed treatment of `.sa-chip-ambiguous` on purpose: both are caveats on the row's finding rather than findings themselves, and neither may compete visually with the red/green scope chips beside them.

It renders nothing for a non-numeric count. The value is server-supplied, and a truthiness check would put the literal string `NaN forwarded packets` on the page if that ever stopped holding.

## Docs

`docs/api-spec.md` had **no entry for `GET /api/scope-audit` at all**, so this adds one: query parameter, full response shape, and the notes a client needs (the three traps the per-node endpoint documents apply here identically, `*` is never a scope, and "never asked" is not "declared nothing"). The new field is documented there rather than in isolation.

## Tests

- the counter on a last-hop and on a mid-path hop
- an unmatched packet enters neither `agg.scopes` nor `unscopedPackets`, which is the confusion this field exists to prevent
- the field on the API row
- six frontend cases: zero renders nothing, a missing field renders nothing (older server), the chip carries its count and class, singular and plural are both grammatical, the title names the cause and the fix, and a non-numeric count renders nothing rather than `NaN`

`cd cmd/server && go test ./...` passes, frontend 712 assertions pass, `go vet` and `gofmt -l` clean.

Rule 0: the counter is one increment on a branch that already existed as a `continue`, inside a loop this PR does not change. No new query, no new pass over the data.