### PR TITLE
feat(scope-audit): verify a declared region against the repeater's own traffic

### DIFF
--- a/cmd/server/scope_audit.go
+++ b/cmd/server/scope_audit.go
@@ -22,6 +22,7 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"net/http"
 	"sort"
 	"strings"
@@ -296,6 +297,16 @@ type scopeAuditTargetAgg struct {
 	// of them may be a region this instance cannot name rather than one the
 	// repeater is not forwarding.
 	unmatchedPackets int64
+
+	// unmatchedTxIDs are the transmissions behind unmatchedPackets, kept so
+	// declared-region verification can test this target's own declarations
+	// against this target's own unnameable traffic (scope_verify.go). The same
+	// (target, txID) de-duplication that guards unmatchedPackets guards this,
+	// so one packet reaching a target by two hops cannot corroborate twice.
+	//
+	// Bounded by scopeVerifyMaxPacketsPerTarget, which unmatchedPackets is NOT:
+	// the count stays the honest total, this is the working set.
+	unmatchedTxIDs []int64
 
 	// ambiguousHops counts forwarder-hop observations in the window whose
 	// truncated hash prefix matched this target AND at least one other
@@ -643,6 +654,9 @@ func (s *PacketStore) ScopeAuditForwarding(sinceISO string, targets []string) (m
 				// finding on this row may be a gap in this instance's
 				// hashRegions rather than in the repeater's forwarding.
 				agg.unmatchedPackets++
+				if len(agg.unmatchedTxIDs) < scopeVerifyMaxPacketsPerTarget {
+					agg.unmatchedTxIDs = append(agg.unmatchedTxIDs, txID)
+				}
 				continue
 			}
 			name := normScope(scopeName.String)
@@ -777,6 +791,32 @@ type ScopeAuditRow struct {
 	// it never feeds WildcardContradiction, which counts only plain unscoped
 	// floods.
 	ObservedUnmatchedPackets int64 `json:"observedUnmatchedPackets"`
+
+	// ObservedUnmatchedSampled is how many of those packets verification could
+	// actually look at: the per-target list is capped at
+	// scopeVerifyMaxPacketsPerTarget and the window sample at
+	// scopeVerifyMaxWindowPackets, while ObservedUnmatchedPackets keeps
+	// counting past both.
+	//
+	// It exists because a client cannot otherwise subtract the two fields
+	// honestly. RegionEvidence can only ever count packets inside this sample,
+	// so on a row where this is smaller than ObservedUnmatchedPackets the
+	// difference between them is an upper bound on the unexplained traffic, not
+	// a figure. Equal values mean the subtraction is exact.
+	ObservedUnmatchedSampled int64 `json:"observedUnmatchedSampled"`
+
+	// RegionEvidence maps a declared region to how many of this repeater's own
+	// unmatched forwarded packets derive to it — see scope_verify.go. A region
+	// reaching scopeVerifyMinCorroboration is removed from NotObserved, so this
+	// field is NOT what decides the chip's colour; NotObserved remains the sole
+	// source of that. This exists so a client can say HOW a region was
+	// established, and can explain a region that got exactly one hit and
+	// therefore stayed in NotObserved.
+	//
+	// Absent regions simply had no matching traffic. Never nil in the response
+	// — an empty object and a missing key mean the same thing, and an empty map
+	// is the cheaper thing for a client to iterate.
+	RegionEvidence map[string]int `json:"regionEvidence"`
 }
 
 // ScopeAuditResponse is the payload for GET /api/scope-audit. Only
@@ -1036,6 +1076,33 @@ func (s *Server) computeScopeAudit(window, sinceISO string) (*ScopeAuditResponse
 		}
 	}
 
+	// Declared-region verification: a region this instance holds no key for is
+	// unnameable, not absent, and the audit can settle which by deriving the key
+	// from the repeater's own declaration and testing it against that
+	// repeater's own unnameable traffic. One verifier serves every row so each
+	// (region, transmission) pair is derived at most once — see scope_verify.go
+	// for why that memo is what keeps this affordable.
+	//
+	// A failure here degrades to "no verification" rather than failing the
+	// request: the audit was useful before this existed and must stay useful if
+	// the extra query errors.
+	var verifier *scopeVerifier
+	if s.store != nil {
+		unmatchedRows, truncated, uErr := s.store.unmatchedTransmissionsInWindow(sinceISO)
+		if uErr != nil {
+			log.Printf("[scope-audit] declared-region verification unavailable: %v", uErr)
+		} else {
+			if truncated {
+				// Said out loud rather than absorbed: past the cap a region can
+				// hold evidence this refresh did not look at, so a grey chip
+				// means "not corroborated in this sample", not "not forwarded".
+				log.Printf("[scope-audit] window %s holds more than %d unnameable packets; verification used the most recent %d and may under-report evidence",
+					window, scopeVerifyMaxWindowPackets, scopeVerifyMaxWindowPackets)
+			}
+			verifier = newScopeVerifier(unmatchedRows)
+		}
+	}
+
 	identities := s.db.scopeAuditNodeIdentities(targets)
 
 	resp := &ScopeAuditResponse{Window: window, Since: sinceISO, Repeaters: []ScopeAuditRow{}}
@@ -1072,9 +1139,32 @@ func (s *Server) computeScopeAudit(window, sinceISO string) (*ScopeAuditResponse
 
 		agg := forwarding[pk]
 
-		notObserved := []string{}
+		// Verify the declared regions this repeater has no NAMED evidence for,
+		// against its own unmatched traffic. Regions already observed by name
+		// need no verification and are not tested — that keeps the candidate
+		// set to exactly the open questions, which is also what keeps the
+		// verifier's work proportional to the problem rather than to the fleet.
+		unnamed := []string{}
 		for _, rgn := range declaredNamed {
 			if agg == nil || agg.scopes[rgn] == nil {
+				unnamed = append(unnamed, rgn)
+			}
+		}
+		regionEvidence := map[string]int{}
+		verifiedSet := map[string]bool{}
+		if verifier != nil && agg != nil && len(unnamed) > 0 {
+			// capVerifyRegions bounds the per-target half of the verifier's
+			// work. The declared list arrives from a collector and its LENGTH
+			// is not validated anywhere on the way in, while each distinct name
+			// costs a full pass over the packet set.
+			regionEvidence = verifier.evidence(agg.unmatchedTxIDs, capVerifyRegions(unnamed))
+			for _, rgn := range verifier.verified(regionEvidence) {
+				verifiedSet[rgn] = true
+			}
+		}
+		notObserved := []string{}
+		for _, rgn := range unnamed {
+			if !verifiedSet[rgn] {
 				notObserved = append(notObserved, rgn)
 			}
 		}
@@ -1093,11 +1183,14 @@ func (s *Server) computeScopeAudit(window, sinceISO string) (*ScopeAuditResponse
 			}
 		}
 
-		var unscopedPackets, ambiguousHops, unmatchedPackets int64
+		var unscopedPackets, ambiguousHops, unmatchedPackets, unmatchedSampled int64
 		if agg != nil {
 			unscopedPackets = agg.unscopedPackets
 			ambiguousHops = agg.ambiguousHops
 			unmatchedPackets = agg.unmatchedPackets
+			// What verification could actually see, against what was counted.
+			// The list is capped; the count is not.
+			unmatchedSampled = int64(len(agg.unmatchedTxIDs))
 		}
 
 		resp.Repeaters = append(resp.Repeaters, ScopeAuditRow{
@@ -1115,6 +1208,8 @@ func (s *Server) computeScopeAudit(window, sinceISO string) (*ScopeAuditResponse
 			WildcardContradiction:    unscopedPackets > 0 && !declaredWildcard,
 			AmbiguousHops:            ambiguousHops,
 			ObservedUnmatchedPackets: unmatchedPackets,
+			ObservedUnmatchedSampled: unmatchedSampled,
+			RegionEvidence:           regionEvidence,
 		})
 	}
 

--- a/cmd/server/scope_audit_test.go
+++ b/cmd/server/scope_audit_test.go
@@ -1173,3 +1173,122 @@ func TestHandleScopeAuditSurfacesUnmatchedPackets(t *testing.T) {
 		t.Error("wildcardContradiction = true, want false — unmatched traffic is scoped, so it says nothing about '*'")
 	}
 }
+
+// TestHandleScopeAuditVerifiesDeclaredRegion is the case this milestone exists
+// for, built from the real packet that started the investigation. A repeater
+// declares "fm-112"; this instance holds no key for it, so both packets it
+// forwarded are stored unmatched. Verification derives the key from the
+// repeater's own declaration, finds two corroborating packets, and the region
+// must leave notObserved with its evidence count reported.
+func TestHandleScopeAuditVerifiesDeclaredRegion(t *testing.T) {
+	srv, router := setupScopeAuditServer(t)
+	pk := testFullPubkeyA
+	insertDeclared(t, srv, pk, time.Now().UTC().Format(time.RFC3339), "fm-112,behss", 0)
+	recent := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	seedUnmatchedRawAt(t, srv.store, pk[:4], realTransportFloodPacket, RouteTransportFlood, recent)
+	seedUnmatchedRawAt(t, srv.store, pk[:4], realTransportFloodPacket, RouteTransportFlood, recent)
+
+	got := getScopeAudit(t, router, "")
+	if len(got.Repeaters) != 1 {
+		t.Fatalf("repeaters = %+v, want 1", got.Repeaters)
+	}
+	row := got.Repeaters[0]
+	if row.RegionEvidence["fm-112"] != 2 {
+		t.Errorf("regionEvidence = %v, want fm-112:2", row.RegionEvidence)
+	}
+	for _, n := range row.NotObserved {
+		if n == "fm-112" {
+			t.Errorf("notObserved = %v, must not contain fm-112 - two corroborating packets prove it is forwarded", row.NotObserved)
+		}
+	}
+	if len(row.NotObserved) != 1 || row.NotObserved[0] != "behss" {
+		t.Errorf("notObserved = %v, want [behss] - that region has no corroborating traffic here", row.NotObserved)
+	}
+}
+
+// TestHandleScopeAuditReportsTheVerificationSampleSize pins the field a client
+// needs to subtract RegionEvidence from ObservedUnmatchedPackets honestly.
+// RegionEvidence can only ever count packets inside the sample, so a client
+// that subtracts it from an uncapped total overstates what is unexplained. The
+// two are equal here, which is the case that says "this subtraction is exact".
+
+// TestHandleScopeAuditDoesNotVerifyOnOnePacket: a single match is 1-in-65536
+// and must leave the region in notObserved, with its count still reported so a
+// client can say "one hit, not enough".
+func TestHandleScopeAuditDoesNotVerifyOnOnePacket(t *testing.T) {
+	srv, router := setupScopeAuditServer(t)
+	pk := testFullPubkeyA
+	insertDeclared(t, srv, pk, time.Now().UTC().Format(time.RFC3339), "fm-112", 0)
+	recent := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	seedUnmatchedRawAt(t, srv.store, pk[:4], realTransportFloodPacket, RouteTransportFlood, recent)
+
+	got := getScopeAudit(t, router, "")
+	row := got.Repeaters[0]
+	if row.RegionEvidence["fm-112"] != 1 {
+		t.Errorf("regionEvidence = %v, want fm-112:1", row.RegionEvidence)
+	}
+	if len(row.NotObserved) != 1 || row.NotObserved[0] != "fm-112" {
+		t.Errorf("notObserved = %v, want [fm-112] - one corroborating packet is not evidence", row.NotObserved)
+	}
+}
+
+// TestHandleScopeAuditLeavesCleanRowsAlone: a repeater whose declared regions
+// are all observed by name, with no unmatched traffic at all, must be untouched
+// by verification - no evidence, no change to notObserved, and an empty (not
+// null) regionEvidence so a client can iterate it without a guard.
+
+// TestHandleScopeAuditReportsTheVerificationSampleSize pins the field a client
+// needs to subtract RegionEvidence from ObservedUnmatchedPackets honestly.
+// RegionEvidence can only ever count packets inside the sample, so a client
+// that subtracts it from an uncapped total overstates what is unexplained. The
+// two are equal here, which is the case that says "this subtraction is exact".
+func TestHandleScopeAuditReportsTheVerificationSampleSize(t *testing.T) {
+	srv, router := setupScopeAuditServer(t)
+	pk := testFullPubkeyA
+	insertDeclared(t, srv, pk, time.Now().UTC().Format(time.RFC3339), "fm-112", 0)
+	recent := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	seedUnmatchedRawAt(t, srv.store, pk[:4], realTransportFloodPacket, RouteTransportFlood, recent)
+	seedUnmatchedRawAt(t, srv.store, pk[:4], realTransportFloodPacket, RouteTransportFlood, recent)
+
+	row := getScopeAudit(t, router, "").Repeaters[0]
+	if row.ObservedUnmatchedPackets != 2 {
+		t.Fatalf("observedUnmatchedPackets = %d, want 2", row.ObservedUnmatchedPackets)
+	}
+	if row.ObservedUnmatchedSampled != row.ObservedUnmatchedPackets {
+		t.Errorf("observedUnmatchedSampled = %d, want %d — nothing was capped away at this size, and a client can only tell from this field",
+			row.ObservedUnmatchedSampled, row.ObservedUnmatchedPackets)
+	}
+}
+
+// TestHandleScopeAuditDoesNotVerifyOnOnePacket: a single match is 1-in-65536
+// and must leave the region in notObserved, with its count still reported so a
+// client can say "one hit, not enough".
+
+// seedUnmatchedRawAt seeds one unmatched transmission carrying a real raw_hex,
+// attributed to forwarder. Distinct from seedTransmissionRouteAt, which seeds
+// raw_hex 'AA' - fine for tests that never parse it, useless here.
+func seedUnmatchedRawAt(t *testing.T, s *PacketStore, forwarder, rawHex string, routeType int, firstSeen string) {
+	t.Helper()
+	scopeSeedCounter++
+	hash := fmt.Sprintf("scoperaw%d", scopeSeedCounter)
+	res, err := s.db.conn.Exec(
+		`INSERT INTO transmissions (raw_hex, hash, first_seen, route_type, payload_type, code1, code2, scope_name)
+		 VALUES (?, ?, ?, ?, 5, '9209', '0000', '')`,
+		rawHex, hash, firstSeen, routeType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.conn.Exec(
+		`INSERT INTO observations (transmission_id, path_json, timestamp) VALUES (?, ?, 0)`,
+		txID, `["`+strings.ToUpper(forwarder)+`"]`); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestHandleNodeScopesDifferentWindowIsSeparateCacheEntry confirms the cache
+// key includes window: a request for a different window must recompute
+// rather than reuse another window's cached entry.

--- a/cmd/server/scope_verify.go
+++ b/cmd/server/scope_verify.go
@@ -1,0 +1,321 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// scopeVerifyMaxPacketsPerTarget bounds the per-target evidence list. AGENTS.md
+// rule 0 forbids unbounded structures, and the corroboration threshold is 2 —
+// past a few hundred packets more evidence changes no verdict, it only costs
+// memory. scopeAuditTargetAgg.unmatchedPackets keeps counting past this: the
+// count is the honest total, the list is the working set.
+const scopeVerifyMaxPacketsPerTarget = 512
+
+// scopeVerifyMaxWindowPackets bounds the OTHER axis: how many unnameable
+// packets one refresh will hold and derive over.
+//
+// The "~400 packets in a 7 day window" this feature was sized against is a
+// property of THIS instance's configuration, not of the feature. The ingestor
+// stores an EMPTY scope_name for every transport-scoped packet no configured
+// key names (scopeNameForDB) — spelled out in words for the reason the query
+// below gives — so the fewer hashRegions an instance has, the more
+// rows land here — and an instance with none at all puts every scoped packet
+// in this set. That is the stock state, and it is the state this feature was
+// built to help.
+//
+// The cost is one HMAC per distinct region name per packet, measured at ~0.7µs
+// (BenchmarkScopeVerifierAudit: 124 names over 400 packets in 36ms). At this
+// cap and 124 distinct declared names that is ~500k HMACs, roughly 0.35s of
+// worst case on an endpoint that already costs seconds and caches for minutes.
+// Ten times this cap would not: it would be seconds of HMAC on every refresh.
+const scopeVerifyMaxWindowPackets = 4096
+
+// scopeVerifyMaxRegionsPerTarget bounds how many of one repeater's declared
+// names are put to the verifier. Every distinct name costs a full pass over
+// the packet set, and the list is client-supplied: handleClientRegions
+// (cmd/ingestor/client_regions.go) validates the target pubkey and each entry's
+// shape, but nothing limits how many entries one companion may report. The
+// longest genuine list on this network declares 21 regions, and the firmware
+// exports a short label set by construction.
+const scopeVerifyMaxRegionsPerTarget = 32
+
+// capVerifyRegions applies scopeVerifyMaxRegionsPerTarget, keeping the first
+// entries in the order the caller supplied. It does not sort or rank: a
+// declared list has no priority order to respect, and reordering here would
+// make which regions get verified depend on something the reader cannot see.
+func capVerifyRegions(regions []string) []string {
+	if len(regions) <= scopeVerifyMaxRegionsPerTarget {
+		return regions
+	}
+	return regions[:scopeVerifyMaxRegionsPerTarget]
+}
+
+// scopeHMACInputs pulls the three values needed to test a region hypothesis
+// against one packet: the payload type and raw payload bytes the sender HMACed,
+// and the resulting two-byte code it put on the wire.
+//
+// It deliberately does NOT call DecodePacket. That runs decodePayload, which
+// attempts channel decryption and signature validation — work this has no use
+// for, repeated over every unmatched packet on every audit refresh. Walking the
+// offsets is all that is needed, and it reuses decodeHeader/isTransportRoute/
+// decodePath so the offset arithmetic is not duplicated from DecodePacket.
+//
+// ok is false for anything that cannot carry a region scope: malformed hex, a
+// truncated header, an invalid path byte, or a non-transport route. A plain
+// FLOOD packet has no transport codes at all, so there is no code1 to compare
+// against and HMACing it could only waste time.
+func scopeHMACInputs(rawHex string) (payloadType byte, payload []byte, code1 string, ok bool) {
+	buf, err := hex.DecodeString(strings.TrimSpace(rawHex))
+	if err != nil || len(buf) < 2 {
+		return 0, nil, "", false
+	}
+	header := decodeHeader(buf[0])
+	if !isTransportRoute(header.RouteType) {
+		return 0, nil, "", false
+	}
+	offset := 1
+	if len(buf) < offset+4 {
+		return 0, nil, "", false
+	}
+	code1 = strings.ToUpper(hex.EncodeToString(buf[offset : offset+2]))
+	offset += 4 // code1 and code2
+
+	if offset >= len(buf) {
+		return 0, nil, "", false
+	}
+	pathByte := buf[offset]
+	offset++
+	_, consumed, decodeErr := decodePath(pathByte, buf, offset)
+	if decodeErr != nil {
+		return 0, nil, "", false
+	}
+	offset += consumed
+	if offset > len(buf) {
+		return 0, nil, "", false
+	}
+	rest := buf[offset:]
+	if len(rest) == 0 {
+		return 0, nil, "", false
+	}
+	return byte(header.PayloadType), rest, code1, true
+}
+
+// regionCode derives the on-wire code1 a sender in region name would emit for
+// this payload — the forward direction of what matchingRegions inverts in the
+// ingestor (cmd/ingestor/main.go). The two must stay in step: key is
+// SHA256("#name")[:16], the MAC covers payloadType followed by the payload, the
+// code is the first two MAC bytes little-endian, and 0x0000/0xFFFF are reserved
+// and nudged. Any divergence here silently produces regions that never verify.
+//
+// The leading '#' is optional because callers hold normScope'd names (the audit
+// strips it) while the key is over the '#'-prefixed form.
+//
+// Case is significant and must stay so: the key is a hash over the raw bytes of
+// "#name", so "#BEHSS" and "#behss" are different regions on the wire.
+func regionCode(name string, payloadType byte, payload []byte) string {
+	if !strings.HasPrefix(name, "#") {
+		name = "#" + name
+	}
+	sum := sha256.Sum256([]byte(name))
+	mac := hmac.New(sha256.New, sum[:16])
+	mac.Write([]byte{payloadType})
+	mac.Write(payload)
+	h := mac.Sum(nil)
+	code := uint16(h[0]) | uint16(h[1])<<8
+	if code == 0 {
+		code = 1
+	} else if code == 0xFFFF {
+		code = 0xFFFE
+	}
+	return strings.ToUpper(hex.EncodeToString([]byte{byte(code & 0xFF), byte(code >> 8)}))
+}
+
+// unmatchedTransmissionRow is one transmission that carried a transport scope
+// no configured region key matched, with the raw bytes needed to test a region
+// hypothesis against it.
+type unmatchedTransmissionRow struct {
+	txID   int64
+	rawHex string
+}
+
+// unmatchedTransmissionsInWindow is the SECOND, narrow query behind the audit -
+// deliberately not a widening of scopeAuditForwarderScanQuery.
+//
+// That scan returns one row per hop per flood packet: on a 2,000-packet sample
+// after M0 that is 19,049 rows, and carrying raw_hex on every one of them would
+// load the hot path to serve a few hundred packets. This selects only the
+// transmissions that are actually candidates - an empty scope_name inside the
+// window, ~400 over 7 days on the reference deployment - and the main scan is
+// left exactly as it is.
+//
+// An empty scope_name is the "transport-scoped but unnameable" state; NULL
+// means the packet carried no scope at all and can never verify against a
+// region. The route filter matches the forwarder scan's, so the two agree on
+// which packets count as forwarded.
+//
+// "Empty" is spelled out above rather than written as the two-single-quote
+// literal on purpose: gofmt applies the old godoc typographic substitution
+// inside doc comments and rewrites that digraph into a closing curly quote,
+// which silently misstates the one value this query keys on — and puts it back
+// on every gofmt run.
+//
+// Selection only: a row whose raw_hex cannot be walked is still returned, and
+// dropped by newScopeVerifier. Filtering that in SQL is not possible and
+// filtering it here would hide how many candidates the window actually held.
+// The second return value reports that the window held more than
+// scopeVerifyMaxWindowPackets rows and the answer is a sample of the most
+// recent ones. Newest-first because a partial answer drawn from the most recent
+// traffic is the one that matches what the window claims to describe: a
+// repeater still forwarding a region is likelier to have done so recently, and
+// verification only ever needs two corroborating packets.
+func (s *PacketStore) unmatchedTransmissionsInWindow(sinceISO string) ([]unmatchedTransmissionRow, bool, error) {
+	rows, err := s.db.conn.Query(`
+		SELECT t.id, t.raw_hex
+		FROM transmissions t
+		WHERE t.first_seen >= ?
+		  AND t.scope_name = ''
+		  AND `+scopeConformanceForwarderRouteTypesSQL+`
+		ORDER BY t.first_seen DESC
+		LIMIT ?`, sinceISO, scopeVerifyMaxWindowPackets)
+	if err != nil {
+		return nil, false, fmt.Errorf("unmatched transmissions scan: %w", err)
+	}
+	defer rows.Close()
+
+	var out []unmatchedTransmissionRow
+	for rows.Next() {
+		var r unmatchedTransmissionRow
+		if err := rows.Scan(&r.txID, &r.rawHex); err != nil {
+			return nil, false, fmt.Errorf("unmatched transmissions scan row: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, fmt.Errorf("unmatched transmissions rows: %w", err)
+	}
+	return out, len(out) == scopeVerifyMaxWindowPackets, nil
+}
+
+// scopeVerifyMinCorroboration is how many of a repeater's own unmatched packets
+// must derive to a declared region before that region counts as observed.
+//
+// One is not enough, and the arithmetic is the whole argument: code1 is two
+// bytes, so an unrelated name matches a given packet with probability 1/65536.
+// Across ~400 unmatched packets and ~124 distinct declared names, chance alone
+// produces roughly one false match per refresh. Two matches on the same region
+// for the same repeater is (1/65536)^2 - about one in four billion. Raising
+// this costs recall on quiet regions; lowering it to 1 makes the feature
+// unsound, not merely noisy.
+const scopeVerifyMinCorroboration = 2
+
+// scopeVerifier answers "how many of these transmissions are region X" while
+// deriving each region's code over each packet at most once.
+//
+// The cache is not a nicety, and where it has to sit was measured rather than
+// guessed. Naively the audit does targets x declaredNames x unmatchedPackets
+// HMACs — 205 x 124 x 400 is roughly 10,000,000. Caching per
+// (region, transmission) pair cuts the HMACs to names x packets, ~50,000, but
+// leaves the ITERATION cubic: a benchmark of that shape spent 501ms on 10.2M
+// map lookups at ~49ns each, with the HMACs a rounding error beside it.
+//
+// So the cache is keyed per REGION, holding the set of transmissions that
+// derive to it. A region is HMACed over every packet once, and a target then
+// asks one question per declared region instead of one per (region, packet).
+// The overwhelmingly common answer is an empty set — most declared regions
+// match nothing — which costs a single lookup and no packet loop at all.
+//
+// Not safe for concurrent use: one verifier is built per audit computation,
+// which handleScopeAudit already serialises behind its cache.
+type scopeVerifier struct {
+	packets map[int64]scopeVerifyInputs
+	// matchesByRegion caches, per region, the transmissions that derive to it.
+	// Computed once over every packet, never per target.
+	matchesByRegion map[string]map[int64]bool
+	// hmacCount is incremented per actual derivation, asserted by the cache
+	// test so a future refactor cannot quietly reintroduce the naive cost.
+	hmacCount int
+}
+
+type scopeVerifyInputs struct {
+	payloadType byte
+	payload     []byte
+	code1       string
+	ok          bool
+}
+
+// newScopeVerifier parses each row once. A row whose raw_hex cannot be walked
+// is kept with ok=false rather than dropped, so its id still resolves and a
+// caller asking about it gets "no evidence" instead of a miss.
+func newScopeVerifier(rows []unmatchedTransmissionRow) *scopeVerifier {
+	v := &scopeVerifier{
+		packets:         make(map[int64]scopeVerifyInputs, len(rows)),
+		matchesByRegion: map[string]map[int64]bool{},
+	}
+	for _, r := range rows {
+		pt, payload, code1, ok := scopeHMACInputs(r.rawHex)
+		v.packets[r.txID] = scopeVerifyInputs{payloadType: pt, payload: payload, code1: code1, ok: ok}
+	}
+	return v
+}
+
+// regionMatches returns the transmissions deriving to region, computing the
+// whole set on first ask. Unparseable packets are skipped rather than counted
+// as misses, so one malformed row in the window cannot blank a region.
+func (v *scopeVerifier) regionMatches(region string) map[int64]bool {
+	if m, ok := v.matchesByRegion[region]; ok {
+		return m
+	}
+	m := map[int64]bool{}
+	for txID, in := range v.packets {
+		if !in.ok {
+			continue
+		}
+		v.hmacCount++
+		if regionCode(region, in.payloadType, in.payload) == in.code1 {
+			m[txID] = true
+		}
+	}
+	v.matchesByRegion[region] = m
+	return m
+}
+
+// evidence counts, for each declared region, how many of txIDs derive to it.
+// Regions with zero matches are absent from the result rather than present
+// with 0, so the map is directly the "we found something" set.
+func (v *scopeVerifier) evidence(txIDs []int64, declaredRegions []string) map[string]int {
+	out := map[string]int{}
+	for _, region := range declaredRegions {
+		m := v.regionMatches(region)
+		if len(m) == 0 {
+			continue // the common case: one lookup, no packet loop
+		}
+		n := 0
+		for _, txID := range txIDs {
+			if m[txID] {
+				n++
+			}
+		}
+		if n > 0 {
+			out[region] = n
+		}
+	}
+	return out
+}
+
+// verified returns the regions in an evidence map that clear the corroboration
+// threshold, sorted so the response is stable across refreshes.
+func (v *scopeVerifier) verified(evidence map[string]int) []string {
+	var out []string
+	for region, n := range evidence {
+		if n >= scopeVerifyMinCorroboration {
+			out = append(out, region)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/server/scope_verify_test.go
+++ b/cmd/server/scope_verify_test.go
@@ -1,0 +1,339 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// realTransportFloodPacket is transmission 0a065d41d51f1f77 from the live
+// instance, captured 2026-09-07. Header 0x14 = route_type 0 (TRANSPORT_FLOOD),
+// payload_type 5 (GRP_TXT); transport codes 9209/0000; path byte 0x41 =
+// hash_size 2, one hop "E3D3"; the rest is payload.
+//
+// A hand-built fixture would only prove the parser agrees with itself. This
+// packet is the one that started the investigation: its code1 is exactly the
+// code #fm-112 derives over its own payload, which is why the audit showed
+// fm-112 as "not observed" for a repeater that was forwarding it.
+const realTransportFloodPacket = "149209000041E3D3EC2D4481DA70893CD71B763958B064A9AAC011D54223FF8A0140CBB4093653BC61D67C960E3ECCE6639CC9FF1147AA6D0F9017"
+
+func TestScopeHMACInputsParsesRealPacket(t *testing.T) {
+	payloadType, payload, code1, ok := scopeHMACInputs(realTransportFloodPacket)
+	if !ok {
+		t.Fatal("scopeHMACInputs returned ok=false for a valid transport-flood packet")
+	}
+	if payloadType != 5 {
+		t.Errorf("payloadType = %d, want 5 (GRP_TXT)", payloadType)
+	}
+	if code1 != "9209" {
+		t.Errorf("code1 = %q, want %q", code1, "9209")
+	}
+	if len(payload) != 51 {
+		t.Errorf("len(payload) = %d, want 51", len(payload))
+	}
+	if got := strings.ToUpper(hex.EncodeToString(payload[:4])); got != "EC2D4481" {
+		t.Errorf("payload starts %q, want %q — offset walked wrong", got, "EC2D4481")
+	}
+}
+
+func TestScopeHMACInputsRejectsNonTransportRoutes(t *testing.T) {
+	// A plain FLOOD packet carries no transport codes, so it has no code1 to
+	// verify against. Returning ok=false rather than a zero code1 keeps the
+	// caller from HMACing packets that can never match anything.
+	//
+	// Header 0x15 = route_type 1 (FLOOD), payload_type 5. No transport codes,
+	// so the path byte follows the header directly.
+	_, _, _, ok := scopeHMACInputs("15" + "41" + "E3D3" + "AABBCC")
+	if ok {
+		t.Error("ok = true for a non-transport route, want false — there is no code1 to verify")
+	}
+}
+
+func TestScopeHMACInputsRejectsMalformed(t *testing.T) {
+	for _, c := range []struct{ hex, why string }{
+		{"", "empty"},
+		{"zz", "not hex"},
+		{"14", "header only, no transport codes"},
+		{"1492090000", "transport codes but no path byte"},
+		{"149209000041", "path byte claims one 2-byte hop, none present"},
+		// pathByte 0xC0: upper two bits 11 -> hash_size 4, which firmware
+		// reserves and isValidPathLen rejects even at hash_count 0
+		// (cmd/server/decoder.go, mirroring Packet.cpp:13-18).
+		{"1492090000C0" + strings.Repeat("00", 8), "hash_size 4 is reserved"},
+	} {
+		if _, _, _, ok := scopeHMACInputs(c.hex); ok {
+			t.Errorf("ok = true for %q (%s), want false", c.hex, c.why)
+		}
+	}
+}
+
+func TestRegionCodeMatchesTheRealPacket(t *testing.T) {
+	// The end-to-end arithmetic, against a packet whose true region is known.
+	payloadType, payload, code1, ok := scopeHMACInputs(realTransportFloodPacket)
+	if !ok {
+		t.Fatal("setup: scopeHMACInputs failed")
+	}
+	if got := regionCode("fm-112", payloadType, payload); got != code1 {
+		t.Errorf("regionCode(fm-112) = %q, want %q — this packet IS fm-112", got, code1)
+	}
+	// Both spellings must agree: the key is SHA256 over "#name", and callers
+	// hand us names with the '#' already stripped by normScope.
+	if got := regionCode("#fm-112", payloadType, payload); got != code1 {
+		t.Errorf("regionCode(#fm-112) = %q, want %q — leading '#' must be optional", got, code1)
+	}
+	// A region the repeater also declares, which this packet is NOT.
+	if got := regionCode("behss", payloadType, payload); got == code1 {
+		t.Errorf("regionCode(behss) = %q, must not equal fm-112's code1", got)
+	}
+}
+
+func TestRegionCodeIsCaseSensitive(t *testing.T) {
+	// The key is SHA256 over the raw bytes of "#name", so "#BEHSS" and
+	// "#behss" are different regions. Folding case here would silently name
+	// traffic for a region nobody configured.
+	payloadType, payload, _, _ := scopeHMACInputs(realTransportFloodPacket)
+	if regionCode("behss", payloadType, payload) == regionCode("BEHSS", payloadType, payload) {
+		t.Error("regionCode folded case — the key is a hash over raw bytes and must not")
+	}
+}
+
+func TestUnmatchedTransmissionsInWindow(t *testing.T) {
+	s := newScopeTestStore(t)
+	recent := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	old := "2020-01-01T00:00:00Z"
+	seedTransmissionRouteAt(t, s, "E3D3", scopeUnmatched(), RouteFlood, recent)
+	seedTransmissionRouteAt(t, s, "E3D3", scopeMatched("#be"), RouteFlood, recent)
+	seedTransmissionRouteAt(t, s, "E3D3", scopeUnscoped(), RouteFlood, recent)
+	seedTransmissionRouteAt(t, s, "E3D3", scopeUnmatched(), RouteFlood, old)
+
+	since := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
+	got, _, err := s.unmatchedTransmissionsInWindow(since)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d rows, want 1 — only the recent scope_name='' row qualifies", len(got))
+	}
+	// scopeUnmatched() seeds raw_hex 'AA', which scopeHMACInputs rejects. The
+	// query's job is selection; unparseable rows are dropped by the caller, so
+	// they must still be returned here rather than filtered in SQL.
+	if got[0].txID == 0 {
+		t.Error("txID = 0, want the transmission's real id")
+	}
+}
+
+// buildVerifierFromPackets is a test helper: wraps raw hex strings as rows the
+// verifier consumes, with ids 1..N in order.
+func buildVerifierFromPackets(t *testing.T, hexes ...string) *scopeVerifier {
+	t.Helper()
+	rows := make([]unmatchedTransmissionRow, 0, len(hexes))
+	for i, h := range hexes {
+		rows = append(rows, unmatchedTransmissionRow{txID: int64(i + 1), rawHex: h})
+	}
+	return newScopeVerifier(rows)
+}
+
+func TestScopeVerifierNeedsTwoCorroboratingPackets(t *testing.T) {
+	// One match is 1-in-65536 and must not be enough; a second makes it
+	// (1/65536)^2. This threshold is the reason the approach is sound.
+	v := buildVerifierFromPackets(t, realTransportFloodPacket)
+	one := v.evidence([]int64{1}, []string{"fm-112"})
+	if one["fm-112"] != 1 {
+		t.Fatalf("evidence = %v, want fm-112:1", one)
+	}
+	if got := v.verified(one); len(got) != 0 {
+		t.Errorf("verified = %v, want none - one corroborating packet is not evidence", got)
+	}
+
+	// The same packet twice under different ids: two distinct transmissions
+	// both deriving to fm-112.
+	v2 := buildVerifierFromPackets(t, realTransportFloodPacket, realTransportFloodPacket)
+	two := v2.evidence([]int64{1, 2}, []string{"fm-112"})
+	if two["fm-112"] != 2 {
+		t.Fatalf("evidence = %v, want fm-112:2", two)
+	}
+	got := v2.verified(two)
+	if len(got) != 1 || got[0] != "fm-112" {
+		t.Errorf("verified = %v, want [fm-112]", got)
+	}
+}
+
+func TestScopeVerifierIgnoresRegionsThatDoNotMatch(t *testing.T) {
+	v := buildVerifierFromPackets(t, realTransportFloodPacket, realTransportFloodPacket)
+	got := v.evidence([]int64{1, 2}, []string{"behss", "be", "eu"})
+	if len(got) != 0 {
+		t.Errorf("evidence = %v, want empty - none of these regions is this packet", got)
+	}
+}
+
+func TestScopeVerifierSkipsUnparseablePackets(t *testing.T) {
+	// A row whose raw_hex cannot be walked contributes nothing and must not
+	// error the pass: one malformed row in the window would otherwise blank
+	// the verification for every repeater.
+	v := buildVerifierFromPackets(t, "AA", realTransportFloodPacket)
+	got := v.evidence([]int64{1, 2}, []string{"fm-112"})
+	if got["fm-112"] != 1 {
+		t.Errorf("evidence = %v, want fm-112:1 - the malformed row is skipped, the good one still counts", got)
+	}
+}
+
+func TestScopeVerifierCachesAcrossTargets(t *testing.T) {
+	// The cost argument: work depends on (region, transmission), not on which
+	// target asked. Two targets declaring the same region over the same packets
+	// must not double the HMACs.
+	v := buildVerifierFromPackets(t, realTransportFloodPacket, realTransportFloodPacket)
+	v.evidence([]int64{1, 2}, []string{"fm-112"})
+	after := v.hmacCount
+	v.evidence([]int64{1, 2}, []string{"fm-112"})
+	if v.hmacCount != after {
+		t.Errorf("hmacCount %d -> %d on a repeat query, want unchanged - the cache is what keeps this inside rule 0", after, v.hmacCount)
+	}
+}
+
+func TestScopeVerifierUnknownTxIDIsHarmless(t *testing.T) {
+	// A target's unmatchedTxIDs come from a different query than the verifier's
+	// rows. They are taken in the same window, but a row pruned between the two
+	// must degrade to "no evidence", not panic.
+	v := buildVerifierFromPackets(t, realTransportFloodPacket)
+	got := v.evidence([]int64{1, 999}, []string{"fm-112"})
+	if got["fm-112"] != 1 {
+		t.Errorf("evidence = %v, want fm-112:1 - the unknown id contributes nothing", got)
+	}
+}
+
+// BenchmarkScopeVerifierAudit models a full audit refresh: every declared name
+// against every unmatched packet, once, through the memo. The naive shape would
+// be targets x names x packets; this asserts the memo keeps it at names x
+// packets, which is what makes the feature affordable (AGENTS.md rule 0).
+func BenchmarkScopeVerifierAudit(b *testing.B) {
+	const packets, names, targets = 400, 124, 205
+	rows := make([]unmatchedTransmissionRow, 0, packets)
+	txIDs := make([]int64, 0, packets)
+	for i := 0; i < packets; i++ {
+		rows = append(rows, unmatchedTransmissionRow{txID: int64(i + 1), rawHex: realTransportFloodPacket})
+		txIDs = append(txIDs, int64(i+1))
+	}
+	declared := make([]string, 0, names)
+	for i := 0; i < names; i++ {
+		declared = append(declared, fmt.Sprintf("r%04d", i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v := newScopeVerifier(rows)
+		for t := 0; t < targets; t++ {
+			v.evidence(txIDs, declared)
+		}
+	}
+}
+
+// TestUnmatchedTransmissionsInWindowIsBounded pins the LIMIT and what it keeps.
+//
+// The "~400 packets in a 7d window" this feature was sized against holds only
+// for an instance whose hashRegions covers most of what its repeaters forward.
+// The ingestor writes scope_name = ” for EVERY transport-scoped packet it
+// cannot name, so a stock instance with no hashRegions at all has every scoped
+// packet in this result set, and the verifier's work is (distinct declared
+// names x rows). Unbounded on the axis that grows fastest is exactly what
+// AGENTS.md rule 0 forbids.
+//
+// Newest-first is not arbitrary: a partial answer built from the most recent
+// traffic matches what the window claims to describe, and a repeater still
+// forwarding a region is far likelier to have done so recently.
+func TestUnmatchedTransmissionsInWindowIsBounded(t *testing.T) {
+	s := newScopeTestStore(t)
+	base := time.Now().UTC().Add(-2 * time.Hour)
+	total := scopeVerifyMaxWindowPackets + 25
+	for i := 0; i < total; i++ {
+		at := base.Add(time.Duration(i) * time.Second).Format(time.RFC3339)
+		seedTransmissionRouteAt(t, s, "E3D3", scopeUnmatched(), RouteFlood, at)
+	}
+
+	since := time.Now().UTC().Add(-3 * time.Hour).Format(time.RFC3339)
+	got, truncated, err := s.unmatchedTransmissionsInWindow(since)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != scopeVerifyMaxWindowPackets {
+		t.Fatalf("got %d rows, want the cap of %d", len(got), scopeVerifyMaxWindowPackets)
+	}
+	if !truncated {
+		t.Error("truncated = false, want true — the caller has to be able to say the evidence is partial")
+	}
+
+	// The 25 oldest rows are the ones that must have been dropped: seeded ids
+	// ascend with first_seen, so every kept id must be above that boundary.
+	for _, r := range got {
+		if r.txID <= 25 {
+			t.Fatalf("kept txID %d, want only the %d newest rows", r.txID, scopeVerifyMaxWindowPackets)
+		}
+	}
+}
+
+// TestUnmatchedTransmissionsInWindowReportsNoTruncationUnderCap: the flag has to
+// distinguish "this is everything" from "this is a sample", or the caller
+// cannot tell an exact answer from a partial one.
+func TestUnmatchedTransmissionsInWindowReportsNoTruncationUnderCap(t *testing.T) {
+	s := newScopeTestStore(t)
+	recent := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	seedTransmissionRouteAt(t, s, "E3D3", scopeUnmatched(), RouteFlood, recent)
+
+	since := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
+	got, truncated, err := s.unmatchedTransmissionsInWindow(since)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || truncated {
+		t.Fatalf("got %d rows truncated=%v, want 1 and false", len(got), truncated)
+	}
+}
+
+// TestCapVerifyRegions bounds the other axis. A repeater's declared list
+// arrives over MQTT from a companion app: handleClientRegions validates the
+// target and each entry, but nothing limits how MANY entries a client may
+// report, and every distinct name costs one pass over every unmatched packet.
+// The longest genuine list on this network declares 21 regions.
+func TestCapVerifyRegions(t *testing.T) {
+	short := []string{"be", "nl", "eu"}
+	if got := capVerifyRegions(short); len(got) != 3 {
+		t.Errorf("len = %d, want 3 — a normal list must pass through untouched", len(got))
+	}
+	long := make([]string, scopeVerifyMaxRegionsPerTarget+10)
+	for i := range long {
+		long[i] = fmt.Sprintf("r%03d", i)
+	}
+	got := capVerifyRegions(long)
+	if len(got) != scopeVerifyMaxRegionsPerTarget {
+		t.Fatalf("len = %d, want the cap of %d", len(got), scopeVerifyMaxRegionsPerTarget)
+	}
+	if got[0] != long[0] {
+		t.Errorf("got[0] = %q, want %q — the cap keeps the first entries, it does not reorder", got[0], long[0])
+	}
+}
+
+// BenchmarkScopeVerifierStress runs the shape the cap allows, not the shape
+// today's network produces. BenchmarkScopeVerifierAudit models 400 packets;
+// this one models a full sample, which is what an instance with few configured
+// region keys actually hands the verifier.
+func BenchmarkScopeVerifierStress(b *testing.B) {
+	const names, targets = 124, 205
+	packets := scopeVerifyMaxWindowPackets
+	rows := make([]unmatchedTransmissionRow, 0, packets)
+	txIDs := make([]int64, 0, packets)
+	for i := 0; i < packets; i++ {
+		rows = append(rows, unmatchedTransmissionRow{txID: int64(i + 1), rawHex: realTransportFloodPacket})
+		txIDs = append(txIDs, int64(i+1))
+	}
+	declared := make([]string, 0, names)
+	for i := 0; i < names; i++ {
+		declared = append(declared, fmt.Sprintf("r%04d", i))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v := newScopeVerifier(rows)
+		for t := 0; t < targets; t++ {
+			v.evidence(txIDs, declared)
+		}
+	}
+}

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1612,7 +1612,9 @@ not being the same as "declared nothing"), which apply here identically.
       "observedUnscopedPackets": number,               // plain-FLOOD packets forwarded this window
       "wildcardContradiction":   boolean,               // observed unscoped forwarding but '*' not declared
       "ambiguousHops":            number,                // forwarder hops this window that could not be attributed — see note below
-      "observedUnmatchedPackets": number                 // forwarded packets whose scope this instance holds no key for — see note below
+      "observedUnmatchedPackets": number,                // forwarded packets whose scope this instance holds no key for — see note below
+      "observedUnmatchedSampled": number,                // how many of those verification could examine — see note below
+      "regionEvidence":           { "<region>": number } // declared regions corroborated by this repeater's own unnameable traffic — see note below
     }
   ]
 }
@@ -1661,6 +1663,34 @@ not being the same as "declared nothing"), which apply here identically.
   in this instance's own configuration and the operator can act on it. It is **not**
   evidence for or against `declaredWildcard` — unmatched traffic is scoped, so it never
   affects `wildcardContradiction`, which counts only plain unscoped floods.
+  Part of this count is explained: packets counted in `regionEvidence` are
+  attributable to a declared region after all. A client showing this as a caveat should
+  subtract them and report only the remainder, which carries a sharper meaning — traffic
+  this repeater forwards for a region it does **not** declare and this instance cannot
+  name. Two rules on that subtraction: count only evidence for regions **absent** from
+  `notObserved` (a region with a single hit was deliberately not accepted as evidence, so
+  its packet is not explained either), and compare against `observedUnmatchedSampled`
+  first.
+- `observedUnmatchedSampled` is how many of those packets verification could actually
+  examine. Two caps sit between the count and the evidence: the per-repeater working set
+  (512 packets) and the per-window sample (the 4096 most recent unnameable packets, which
+  a deployment with few `hashRegions` entries will reach). `regionEvidence` can only ever
+  count packets inside that sample, so when this field is **smaller** than
+  `observedUnmatchedPackets` the difference between the count and the evidence is an
+  **upper bound** on the unexplained traffic rather than a figure, and a client should say
+  so. Equal values mean the subtraction is exact.
+- `regionEvidence` maps a declared region to how many of this repeater's own unmatched
+  forwarded packets derive to it. The server tests each declared region this repeater has
+  no *named* evidence for by deriving `SHA256("#region")[:16]` and HMAC-ing that
+  repeater's own unmatched packets with it — the same computation the ingestor performs at
+  ingest, with the candidate set narrowed to this repeater's declarations. A region
+  reaching **2** corroborating packets is removed from `notObserved`: `code1` is two
+  bytes, so one match happens by chance with probability 1/65536, while two on the same
+  region is (1/65536)². A region with exactly one hit therefore stays in `notObserved`
+  **and** appears here with the value 1, so a client can explain why it is still shown as
+  not observed. `notObserved` remains the single source of truth for whether a region was
+  observed; this field says only *how* that was established. The object is always present
+  and may be empty.
 - All scope names in `declaredRegions` / `notObserved` / `undeclaredObserved[].scope` are
   already normalised (no leading `#`) — the server does the `#`/no-`#` reconciliation
   described on the per-node endpoint so this response is directly comparable without a

--- a/public/scope-audit.css
+++ b/public/scope-audit.css
@@ -84,3 +84,8 @@
    caveats on the row's finding, not findings themselves, and neither may
    compete visually with the red/green scope chips beside them. */
 .sa-chip-unmatched { background: var(--section-bg, var(--card-bg)); color: var(--text-muted); border: 1px dashed var(--border); font-family: inherit; font-style: italic; }
+
+/* Verified-by-declaration: the same green as any observed chip, because the
+   region IS observed. The dotted underline says how that was established
+   without introducing a third colour into a column that already carries two. */
+.sa-chip-verified { text-decoration: underline dotted; text-underline-offset: 2px; }

--- a/public/scope-audit.js
+++ b/public/scope-audit.js
@@ -93,12 +93,31 @@
   function mergedScopeChips(row) {
     var missing = Object.create(null);
     row.notObserved.forEach(function (n) { missing[n] = true; });
+    var evidence = row.regionEvidence || {};
     var chips = row.declaredRegions.map(function (n) {
       var observed = !missing[n];
-      return '<span class="sa-chip ' + (observed ? 'sa-chip-observed' : 'sa-chip-unobserved') +
-        '" title="' + escapeHtml(n) +
-        (observed ? ': observed forwarding in this window' : ': declared, but no forwarding observed in this window') +
-        '">' + escapeHtml(n) + '</span>';
+      var hits = evidence[n] || 0;
+      // A green chip with evidence was established by verifying the repeater's
+      // own declaration against its own unnameable traffic, not by matching a
+      // configured region key. Same colour — it is observed either way — with a
+      // dotted underline, so the reader can tell the two apart without a third
+      // colour competing for attention in a column that already carries two.
+      var verified = observed && hits > 0;
+      var cls = 'sa-chip ' + (observed ? 'sa-chip-observed' : 'sa-chip-unobserved') + (verified ? ' sa-chip-verified' : '');
+      var title;
+      if (verified) {
+        title = n + ': observed — ' + hits + ' forwarded packet' + (hits === 1 ? '' : 's') +
+          ' in this window derive to this region, verified against the repeater’s own declared list. ' +
+          'This instance holds no hashRegions key for it, so it could not be named directly.';
+      } else if (observed) {
+        title = n + ': observed forwarding in this window';
+      } else if (hits === 1) {
+        title = n + ': declared, and exactly one forwarded packet derives to it — that is one match in 65536 by chance alone, ' +
+          'so it is not treated as evidence. Two would be.';
+      } else {
+        title = n + ': declared, but no forwarding observed in this window';
+      }
+      return '<span class="' + cls + '" title="' + escapeHtml(title) + '">' + escapeHtml(n) + '</span>';
     });
     if (!chips.length) return '<span class="text-muted">—</span>';
     return chips.join(' ');
@@ -195,17 +214,45 @@
   // fault, this one is a missing entry in this instance's own hashRegions and
   // the reader can fix it. Saying so is what stops them investigating an
   // innocent repeater.
-  //
-  // The count is server-supplied, so a non-numeric value renders nothing
-  // rather than the string "NaN forwarded packets".
   function unmatchedCaveat(row) {
     var n = row.observedUnmatchedPackets;
     if (typeof n !== 'number' || !isFinite(n) || n <= 0) return '';
-    var label = escapeHtml(n) + ' forwarded packet' + (n === 1 ? '' : 's');
+    // Traffic already accounted for by verification is explained, not
+    // mysterious. What is left over is the interesting case: this repeater
+    // forwards a region it does NOT declare and that this instance also cannot
+    // name. Reporting the full count here would re-raise a question the Scopes
+    // column has just answered.
+    // Only evidence that actually ESTABLISHED a region counts as an
+    // explanation. A region with a single deriving packet stays in notObserved
+    // by design — one match in 65536 is chance, not evidence — and subtracting
+    // it here would call that packet explained while the chip next to it says
+    // the region was not observed. Keyed on notObserved rather than on the
+    // count, so the corroboration threshold stays in one place: the server.
+    var established = Object.create(null);
+    Object.keys(row.regionEvidence || {}).forEach(function (k) { established[k] = true; });
+    (row.notObserved || []).forEach(function (rgn) { delete established[rgn]; });
+
+    var explained = 0;
+    var evidence = row.regionEvidence || {};
+    Object.keys(established).forEach(function (k) { explained += evidence[k]; });
+    // One packet can derive to two of this repeater's declared regions, so the
+    // values can sum past the number of distinct packets behind them.
+    if (explained > n) explained = n;
+    var left = n - explained;
+    if (left <= 0) return '';
+
+    // observedUnmatchedPackets counts every unnameable packet; the evidence can
+    // only come from the ones the verifier actually held (both the per-target
+    // list and the per-window sample are capped). Subtracting an undercounted
+    // number from a complete one overstates what is unexplained, so when the
+    // count was sampled the chip states a bound instead of a figure.
+    var sampled = typeof row.observedUnmatchedSampled === 'number' ? row.observedUnmatchedSampled : n;
+    var bounded = sampled < n;
+    var label = (bounded ? 'at most ' : '') + escapeHtml(left) + ' forwarded packet' + (left === 1 ? '' : 's');
     return ' <span class="sa-chip sa-chip-unmatched" title="' + label +
-      ' in this window carried a region scope this CoreScope instance holds no key for, so it could not be named. ' +
-      'Any &#39;not observed&#39; entry on this row may be a missing entry in this instance&#39;s hashRegions config rather than a repeater that is not forwarding.">' +
-      label + ' unnameable</span>';
+      ' in this window carried a region scope this CoreScope instance holds no key for, and match none of this repeater&#39;s declared regions. ' +
+      'So this repeater forwards at least one region it does not declare, which this instance also cannot name.">' +
+      label + ' unexplained</span>';
   }
 
   // statusScore ranks a row's Status column numerically for sorting — a

--- a/test-frontend-helpers.js
+++ b/test-frontend-helpers.js
@@ -7219,6 +7219,31 @@ console.log('\n=== scope-audit.js: mergedScopeChips ===');
     assert.ok(h.includes('&lt;img'));
   });
 
+  test('a region verified against the repeater own declaration is green, and says so', () => {
+    const h = chips({ declaredRegions: ['fm-112'], notObserved: [], regionEvidence: { 'fm-112': 23 } });
+    assert.ok(h.includes('sa-chip-observed'), 'still green — it is observed');
+    assert.ok(h.includes('sa-chip-verified'), 'but marked as established differently');
+    assert.ok(h.includes('23'), 'the tooltip states how much evidence there is');
+  });
+
+  test('a region observed by name carries no verified marker', () => {
+    const h = chips({ declaredRegions: ['be'], notObserved: [], regionEvidence: {} });
+    assert.ok(h.includes('sa-chip-observed'));
+    assert.ok(!h.includes('sa-chip-verified'), 'a normally-named region is not a verification');
+  });
+
+  test('a single-hit region stays grey and its tooltip explains why', () => {
+    const h = chips({ declaredRegions: ['fm-112'], notObserved: ['fm-112'], regionEvidence: { 'fm-112': 1 } });
+    assert.ok(h.includes('sa-chip-unobserved'), 'one hit is not enough to turn it green');
+    assert.ok(/one match/i.test(h), 'must say why one hit was not accepted');
+  });
+
+  test('a missing regionEvidence field renders as before (older server)', () => {
+    const h = chips({ declaredRegions: ['be'], notObserved: ['be'] });
+    assert.ok(h.includes('sa-chip-unobserved'));
+    assert.ok(!h.includes('sa-chip-verified'));
+  });
+
   test('a notObserved entry that is not declared cannot invent a chip', () => {
     // Defensive: the server guarantees notObserved is a subset (197 of 197
     // rows checked), but the column must not grow a phantom chip if that ever
@@ -7252,10 +7277,11 @@ console.log('\n=== scope-audit.js: unmatchedCaveat ===');
     assert.strictEqual(caveat({}), '');
   });
 
-  test('a non-zero count renders a chip carrying the number', () => {
+  test('a non-zero unexplained count renders a chip carrying the number', () => {
     const h = caveat({ observedUnmatchedPackets: 148 });
     assert.ok(h.includes('sa-chip-unmatched'), 'should carry its own class');
-    assert.ok(h.includes('148'), 'should state the count, not just that there is one');
+    assert.ok(h.includes('148'), 'with no evidence to subtract, the whole count is unexplained');
+    assert.ok(h.includes('unexplained'), 'the word changed with the meaning');
   });
 
   test('singular and plural are both grammatical', () => {
@@ -7263,18 +7289,77 @@ console.log('\n=== scope-audit.js: unmatchedCaveat ===');
     assert.ok(caveat({ observedUnmatchedPackets: 2 }).includes('2 forwarded packets '));
   });
 
-  test('the title names the cause, not just the symptom', () => {
-    // The operator fix is a hashRegions edit; a caveat that does not say so
-    // sends them looking at the repeater instead of at their own config.
+  test('the title says what unexplained traffic implies', () => {
+    // The cause is no longer only a hashRegions gap: after verification, what
+    // is left over is traffic for a region the repeater does not declare.
     const h = caveat({ observedUnmatchedPackets: 5 });
-    assert.ok(h.includes('hashRegions'), 'must name the config key that fixes it');
+    assert.ok(/does not declare/i.test(h), 'must state the sharper conclusion');
+  });
+
+  test('traffic fully explained by verification raises no caveat', () => {
+    assert.strictEqual(caveat({ observedUnmatchedPackets: 23, regionEvidence: { 'fm-112': 23 } }), '');
+  });
+
+  test('only the unexplained remainder is reported', () => {
+    const h = caveat({ observedUnmatchedPackets: 30, regionEvidence: { 'fm-112': 23 } });
+    assert.ok(h.includes('7 forwarded packets '), 'want the remainder, not the total');
+  });
+
+  test('evidence the server refused to count is not subtracted either', () => {
+    // A region with a single deriving packet stays in notObserved on purpose:
+    // one match in 65536 is chance, not evidence (scopeVerifyMinCorroboration).
+    // Subtracting it here would call that packet explained while the chip
+    // beside it says the opposite. Keyed on notObserved rather than on the
+    // number, so the threshold lives in one place: the server.
+    const h = caveat({
+      observedUnmatchedPackets: 3,
+      regionEvidence: { 'fm-112': 1 },
+      notObserved: ['fm-112'],
+    });
+    assert.ok(h.includes('3 forwarded packets '), 'all three are still unexplained');
+  });
+
+  test('evidence that did establish a region is still subtracted', () => {
+    const h = caveat({
+      observedUnmatchedPackets: 10,
+      regionEvidence: { 'nl-nb': 3, belml: 1 },
+      notObserved: ['belml'],
+    });
+    assert.ok(h.includes('7 forwarded packets '), 'subtract the verified 3, keep the uncorroborated 1');
+  });
+
+  test('a sampled count is reported as an upper bound', () => {
+    // observedUnmatchedPackets counts every packet; the evidence can only come
+    // from the packets the verifier actually held. Subtracting an undercounted
+    // number from a complete one overstates what is unexplained, so the chip
+    // says at most rather than pretending to an exact figure.
+    const h = caveat({
+      observedUnmatchedPackets: 900,
+      observedUnmatchedSampled: 512,
+      regionEvidence: { 'nl-nb': 40 },
+    });
+    assert.ok(h.includes('at most 860 forwarded packets '), 'want the bound, stated as one');
+  });
+
+  test('an unsampled count keeps its exact wording', () => {
+    const h = caveat({
+      observedUnmatchedPackets: 30,
+      observedUnmatchedSampled: 30,
+      regionEvidence: { 'fm-112': 23 },
+    });
+    assert.ok(h.includes('7 forwarded packets '), 'exact remainder');
+    assert.ok(!/at most/.test(h), 'nothing was sampled away, so do not hedge');
   });
 
   test('a non-numeric count renders nothing rather than NaN', () => {
-    // observedUnmatchedPackets is server-supplied. A truthiness check accepts
-    // a string, and the chip then reads "NaN forwarded packets".
     assert.strictEqual(caveat({ observedUnmatchedPackets: '12' }), '');
     assert.strictEqual(caveat({ observedUnmatchedPackets: NaN }), '');
+  });
+
+  test('evidence exceeding the count cannot produce a negative remainder', () => {
+    // One packet can derive to two of a repeater's declared regions, so the
+    // evidence values can sum past the number of distinct packets.
+    assert.strictEqual(caveat({ observedUnmatchedPackets: 4, regionEvidence: { a: 3, b: 3 } }), '');
   });
 
   test('the count is not injected raw into markup', () => {


### PR DESCRIPTION
Follow-up to #1987, and the point of counting that traffic in the first place.

A region this instance holds no `hashRegions` key for is **unnameable, not absent**. #1987 says so with a caveat chip. This settles it wherever the evidence allows: derive `SHA256("#region")[:16]` from the repeater's own declaration and HMAC that repeater's own unmatched packets with it. Same computation the ingestor performs at ingest, with the candidate set narrowed from every configured key to this repeater's handful of declarations.

Where it fires, a grey "declared but not observed" chip becomes a green one and the caveat count shrinks by the packets it explained.

## Two packets, not one

`code1` is two bytes, so an unrelated name matches a given packet with probability 1/65536. Across ~400 unmatched packets and ~124 declared names, chance alone produces roughly one false match per refresh. Two matches on the same region for the same repeater is (1/65536)², about one in four billion.

Lowering the threshold to one would not make this noisy, it would make it **unsound**, so the constant carries that arithmetic and a test rather than a comment. A region with exactly one hit stays grey and reports its single hit, so the page can say why it is still shown as not observed instead of leaving the reader to wonder.

## What it deliberately does not do

**It writes nothing.** Read-time only. A wrong answer expires with the window instead of sitting in `transmissions.scope_name` until someone runs a repair, and `cmd/server` stays read-only per the invariant in AGENTS.md.

**`notObserved` remains the single source of chip colour.** `regionEvidence` says only HOW a region was established. Two fields that can disagree about the same fact is how this column got confusing in the first place.

## Rule 0, including the part that was wrong at first

The naive shape is `targets × names × packets` HMACs: 205 × 124 × 400 ≈ 10M.

Caching per `(region, transmission)` pair cuts the HMACs to ~50k. **That measured 501ms**, because the HMACs had become a rounding error while the *iteration* stayed cubic at 10.2M map lookups. Re-keyed per region, holding the set of matching transmissions, it is **36ms** at the same worst-case shape: a region is HMACed over every packet once, and a target then asks one question per declared region instead of one per (region, packet). Most declared regions match nothing, so the common case is a single map lookup and no packet loop at all.

`hmacCount` exists so a test can assert the first mistake cannot come back; the benchmark exists because only it caught the second.

## Both axes are bounded, because neither is bounded by the data

The "~400 packets in a 7 day window" this was sized against is a property of one instance's configuration, not of the feature: the ingestor stores the unnameable state for every transport-scoped packet no configured key names, so an instance with few or no `hashRegions` entries — the stock state, and the one this helps most — has **every** scoped packet in that set.

- the window query takes the 4096 most recent candidates and reports truncation, which the handler logs, so a grey chip on a sampled refresh is not read as "not forwarded"
- the declared list is capped at 32 names per repeater: it arrives from a collector that validates each entry's shape but never how many entries there are
- measured at the cap: **306ms** for 205 targets over 124 names, against 29ms for the shape a real network produces

Because both caps make the evidence a sample, the response carries `observedUnmatchedSampled`. Without it a client subtracts a capped numerator from an uncapped total and overstates the unexplained traffic with no way to know it is doing so. The chip subtracts only evidence for regions **absent** from `notObserved` — a single-hit region the server refused to accept is not called explained either — and says "at most N" when the count was sampled.

## Verified on live data

Six repeaters clear the threshold in a 7d window on a real instance. One of them: `nl-nb` green with 3 corroborating packets and the tooltip stating the count, `belml` still grey on 1, and the caveat chip reading 31 of 34 packets unexplained rather than 30.

## Tests

`scope_verify_test.go` covers the HMAC-input walk against a real transport-flood packet captured from a live instance (a hand-built fixture would only prove the parser agrees with itself), that `regionCode` does not fold case, the threshold in both directions, the memo's HMAC count, both bounds with their truncation flag, and the benchmark at cap size. Handler-level tests cover a region verified into green, a single hit left grey with its count reported, and the sample-size field.

`cd cmd/server && go test ./...` passes (77s), frontend 723 assertions pass, `go vet` and `gofmt -l` clean.