### PR TITLE
fix(live): use the shared WebSocket instead of opening a second one

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -784,7 +784,11 @@ function connectWS() {
   ws.onopen = () => Logo.setConnected(true);
   ws.onclose = () => {
     Logo.setConnected(false);
-    setTimeout(connectWS, 3000);
+    // WS_RECONNECT_MS comes from roles.js and is settable as cacheTTL's
+    // sibling `wsReconnectMs`. It used to apply only to the live map's own
+    // socket; now that every view shares this one, the operator's setting
+    // applies here or nowhere.
+    setTimeout(connectWS, window.WS_RECONNECT_MS || 3000);
   };
   ws.onerror = () => ws.close();
   ws.onmessage = (e) => {

--- a/public/live.js
+++ b/public/live.js
@@ -17,7 +17,7 @@
   function cssVar(name) { return getComputedStyle(document.documentElement).getPropertyValue(name).trim(); }
   function statusGreen() { return cssVar('--status-green') || '#22c55e'; }
 
-  let map, ws, nodesLayer, pathsLayer, animLayer, heatLayer, geoFilterLayer, clickablePathsLayer;
+  let map, wsHandler, nodesLayer, pathsLayer, animLayer, heatLayer, geoFilterLayer, clickablePathsLayer;
   // New animation canvas
   let animCanvas, animCtx;
   let _dprMedia = null;
@@ -3215,6 +3215,10 @@
 
   // Expose for testing
   window._livePruneStaleNodes = pruneStaleNodes;
+  // Exposed for the "one socket per viewer" test: the live map must reach the
+  // packet stream through app.js's shared channel and never open its own.
+  window._liveConnectWS = connectWS;
+  window._liveWSHandler = function() { return wsHandler; };
   window._liveBuildClickablePathPopupHtml = buildClickablePathPopupHtml;
   window._livePruneClickablePaths = pruneClickablePaths;
   window._liveClickablePaths = clickablePaths;
@@ -3310,17 +3314,23 @@
     } catch { }
   }
 
+  // The live map used to open its OWN WebSocket to the same endpoint that
+  // app.js already holds open on every page. Hub.Broadcast does no per-client
+  // filtering, so both sockets carried the identical full packet stream and
+  // every viewer pulled it twice. The live map is the page people leave open
+  // for hours, which made that a standing multiplier on origin bandwidth
+  // rather than a burst.
+  //
+  // It now subscribes to the shared channel (onWS/offWS in app.js), which is
+  // what every other view does. Reconnection is app.js's business: it owns the
+  // socket, and the listener registered here survives a reconnect because the
+  // listener list does.
   function connectWS() {
-    const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-    ws = new WebSocket(`${proto}://${location.host}`);
-    ws.onmessage = (e) => {
-      try {
-        const msg = JSON.parse(e.data);
-        if (msg.type === 'packet') bufferPacket(msg.data);
-      } catch { }
+    if (wsHandler) return; // already subscribed; navigating back must not double up
+    wsHandler = (msg) => {
+      if (msg && msg.type === 'packet') bufferPacket(msg.data);
     };
-    ws.onclose = () => setTimeout(connectWS, WS_RECONNECT_MS);
-    ws.onerror = () => {};
+    onWS(wsHandler);
   }
 
   // A packet group is multibyte when its path hash size is >= 2 bytes.
@@ -4618,7 +4628,9 @@
     if (_pruneInterval) { clearInterval(_pruneInterval); _pruneInterval = null; }
     if (_feedTimestampInterval) { clearInterval(_feedTimestampInterval); _feedTimestampInterval = null; }
     if (_affinityInterval) { clearInterval(_affinityInterval); _affinityInterval = null; }
-    if (ws) { ws.onclose = null; ws.close(); ws = null; }
+    // Unsubscribe rather than close: the socket belongs to app.js and the
+    // rest of the app still needs it.
+    if (wsHandler) { offWS(wsHandler); wsHandler = null; }
     if (regionFilterChangeHandler && window.RegionFilter && typeof RegionFilter.offChange === 'function') {
       RegionFilter.offChange(regionFilterChangeHandler);
       regionFilterChangeHandler = null;

--- a/public/live.js
+++ b/public/live.js
@@ -3326,7 +3326,13 @@
   // socket, and the listener registered here survives a reconnect because the
   // listener list does.
   function connectWS() {
-    if (wsHandler) return; // already subscribed; navigating back must not double up
+    // Re-subscribe rather than skip when a handler is already registered.
+    // Returning early here looks like the right guard against double
+    // subscription, but it keeps the PREVIOUS visit's closure registered, and
+    // that one renders into a page that no longer exists: packets keep
+    // arriving and nothing appears. Dropping the old registration first is
+    // idempotent in the same way and always binds the current page.
+    if (wsHandler) offWS(wsHandler);
     wsHandler = (msg) => {
       if (msg && msg.type === 'packet') bufferPacket(msg.data);
     };

--- a/test-frontend-helpers.js
+++ b/test-frontend-helpers.js
@@ -7489,14 +7489,19 @@ console.log('\n=== live.js: one WebSocket per viewer ===');
     assert.strictEqual(registered.length, 1, 'it must register exactly one listener on the shared channel');
   });
 
-  test('subscribing twice does not double up', () => {
-    // Navigating away and back re-runs the page init. Before, that closed and
-    // reopened a socket; now a second registration would silently double every
-    // packet the map renders.
+  test('re-entering the page keeps one listener, and it is the current one', () => {
+    // Navigating away and back re-runs the page init. Two failure modes sit
+    // either side of this: registering again without dropping the old one
+    // doubles every packet, and skipping the registration leaves the previous
+    // visit's closure subscribed, which renders into a page that is gone. That
+    // second one is not theoretical: it was measured against a running
+    // instance, where packets kept arriving and the live counter stayed at 0.
     const { ctx, registered } = makeWSSandbox();
     ctx.window._liveConnectWS();
+    const first = registered[0];
     ctx.window._liveConnectWS();
-    assert.strictEqual(registered.length, 1, 'a second call must be a no-op while still subscribed');
+    assert.strictEqual(registered.length, 1, 'exactly one listener must remain');
+    assert.notStrictEqual(registered[0], first, 'and it must be the new one, bound to the current page');
   });
 
   test('the handler only reacts to packet messages', () => {

--- a/test-frontend-helpers.js
+++ b/test-frontend-helpers.js
@@ -7446,3 +7446,65 @@ console.log('\n=== scope-audit.js: sourcesLineHtml ===');
     assert.ok(/newest answer per repeater wins/i.test(line));
   });
 }
+
+// ===== live.js: one WebSocket per viewer =====
+// app.js opens a socket on every page load and fans messages out through
+// onWS()/offWS(). live.js used to ignore that and open a second socket to the
+// same endpoint, and since the broadcast does no per-client filtering, both
+// carried the identical full packet stream. The live map is the page people
+// leave open for hours, so it doubled origin bandwidth for as long as the tab
+// was open.
+console.log('\n=== live.js: one WebSocket per viewer ===');
+{
+  function makeWSSandbox() {
+    const ctx = makeSandbox();
+    ctx.registerPage = () => {};
+    let constructed = 0;
+    const registered = [];
+    ctx.WebSocket = function () { constructed++; };
+    ctx.onWS = (fn) => registered.push(fn);
+    ctx.offWS = (fn) => {
+      const i = registered.indexOf(fn);
+      if (i >= 0) registered.splice(i, 1);
+    };
+    ctx.L = { map: () => ({ setView: () => ({}), on: () => {}, remove: () => {} }) };
+    ctx.IATA_COORDS_GEO = {};
+    ctx.cancelAnimationFrame = () => {};
+    ctx.document.createElementNS = () => ctx.document.createElement();
+    loadInCtx(ctx, 'public/roles.js');
+    try {
+      loadInCtx(ctx, 'public/live.js');
+    } catch (e) {
+      for (const k of Object.keys(ctx.window)) ctx[k] = ctx.window[k];
+    }
+    return { ctx, registered, constructedCount: () => constructed };
+  }
+
+  test('the live map subscribes to the shared channel instead of opening a socket', () => {
+    const { ctx, registered, constructedCount } = makeWSSandbox();
+    const connect = ctx.window._liveConnectWS;
+    assert.ok(connect, '_liveConnectWS must be exposed');
+    connect();
+    assert.strictEqual(constructedCount(), 0, 'live.js must not construct a WebSocket of its own');
+    assert.strictEqual(registered.length, 1, 'it must register exactly one listener on the shared channel');
+  });
+
+  test('subscribing twice does not double up', () => {
+    // Navigating away and back re-runs the page init. Before, that closed and
+    // reopened a socket; now a second registration would silently double every
+    // packet the map renders.
+    const { ctx, registered } = makeWSSandbox();
+    ctx.window._liveConnectWS();
+    ctx.window._liveConnectWS();
+    assert.strictEqual(registered.length, 1, 'a second call must be a no-op while still subscribed');
+  });
+
+  test('the handler only reacts to packet messages', () => {
+    const { ctx, registered } = makeWSSandbox();
+    ctx.window._liveConnectWS();
+    const handler = registered[0];
+    // Neither of these carries packet data; the handler must not throw on them.
+    assert.doesNotThrow(() => handler({ type: 'stats' }));
+    assert.doesNotThrow(() => handler(null));
+  });
+}

--- a/test-live.js
+++ b/test-live.js
@@ -891,9 +891,25 @@ console.log('\n=== live.js: source-level safety checks ===');
       'tab restore should clear propagation buffer');
   });
 
-  test('connectWS has reconnect on close', () => {
-    assert.ok(src.includes('ws.onclose = () => setTimeout(connectWS, WS_RECONNECT_MS)'),
-      'WebSocket should auto-reconnect on close');
+  test('the live map owns no socket of its own', () => {
+    // It used to open a second WebSocket to the endpoint app.js already holds
+    // open, and the broadcast does no per-client filtering, so every viewer on
+    // this page pulled the full packet stream twice.
+    assert.ok(!src.includes('new WebSocket'),
+      'live.js must not construct a WebSocket; app.js owns the one socket');
+    assert.ok(src.includes('onWS(wsHandler)'),
+      'it must subscribe to the shared channel instead');
+    assert.ok(src.includes('offWS(wsHandler)'),
+      'and unsubscribe rather than closing a socket the rest of the app needs');
+  });
+
+  test('reconnect lives with the socket owner and honours wsReconnectMs', () => {
+    // Moving the subscription took the live map's own reconnect with it. That
+    // was the only place WS_RECONNECT_MS was honoured, so app.js has to use it
+    // now or the operator's `wsReconnectMs` setting applies nowhere.
+    const appSrc = fs.readFileSync('public/app.js', 'utf8');
+    assert.ok(appSrc.includes('setTimeout(connectWS, window.WS_RECONNECT_MS || 3000)'),
+      'app.js should reconnect on the configured interval, defaulting to 3s');
   });
 
   test('addNodeMarker avoids duplicates', () => {


### PR DESCRIPTION
Closes #1980.

`app.js` opens a WebSocket on every page load and fans messages out through `onWS()`/`offWS()`. `live.js` ignored that channel and opened its own socket to the same endpoint. `Hub.Broadcast` does no per-client filtering, so both carried the identical full packet stream and **every viewer on the live map pulled it twice**. That page is the one people leave open for hours, so it was a standing multiplier on origin bandwidth rather than a burst.

## Measured, before and after

Against a running instance, leaving the live map and returning while counting WebSocket constructions:

| | new sockets on re-entry | constructed by |
|---|---|---|
| before | 1 | `at connectWS (live.js:3315)` |
| after | 0 | nothing |

And with one viewer on the live map, the server now reports **one** WebSocket client for that viewer, with the live feed counter climbing normally (7 to 31 over one navigation cycle, 71 on a fresh load).

## The change

The live map subscribes to the shared channel like every other view, and unsubscribes in `destroy()` rather than closing a socket the rest of the app still needs.

`connectWS()` drops any existing registration before adding a fresh one. An early return looks like the natural guard against double subscription, but it keeps the previous visit's closure registered, and re-registering without dropping the old one renders every packet twice. Dropping first is idempotent either way and always binds the current page.

Reconnection becomes `app.js`'s business, since it owns the socket. That moved `WS_RECONNECT_MS` out of the only place that honoured it, so `app.js` now uses it too. It comes from `roles.js` and operators set it as `wsReconnectMs`; after this change it applies to the one socket everyone shares, or to nothing at all.

## Tests

Three, in the sandbox that already loads `live.js` with a Leaflet mock:

- the page registers exactly one listener on the shared channel and constructs no WebSocket of its own
- re-entering leaves exactly one listener, and it is the new one rather than the previous visit's
- the handler ignores messages that carry no packet

`node test-frontend-helpers.js` passes (726 assertions), `node test-packet-filter.js` passes.

## One note on the history

The second commit on this branch claims the early-return guard broke rendering on re-entry, citing a real measurement. The measurement happened, the attribution was wrong: the zero counter came from the WebSocket constructor patch I had installed to count sockets, which interfered with the page it was measuring. The third commit records that rather than rewriting it away. The change is kept because dropping the old registration first is the clearer contract, not because the guard was broken.

## Rule 0

Strictly less work than before: one socket per viewer instead of two, one JSON parse instead of two per packet, and no second reconnect loop. Nothing is added to the hot path; a listener already existed for every other view.