### PR TITLE
test(ingestor): make the suite race-clean, and run the detector when it matters

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.scope.outputs.code }}
+      ingestor: ${{ steps.scope.outputs.ingestor }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -66,6 +67,7 @@ jobs:
           # never skipped.
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "ingestor=true" >> "$GITHUB_OUTPUT"
             echo "event=${{ github.event_name }} -> full pipeline"
             exit 0
           fi
@@ -73,6 +75,7 @@ jobs:
           # Empty diff means something is off; run everything rather than guess.
           if [ -z "$CHANGED" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "ingestor=true" >> "$GITHUB_OUTPUT"
             echo "empty diff -> full pipeline"
             exit 0
           fi
@@ -85,6 +88,49 @@ jobs:
             echo "code=false" >> "$GITHUB_OUTPUT"
             echo "-> documentation only, heavy jobs skip (and report Success)"
           fi
+          # The race detector is its own job, and it only earns its ten minutes
+          # when the code it inspects changed. A frontend or docs PR cannot
+          # introduce a data race in the ingestor.
+          if echo "$CHANGED" | grep -qE '^cmd/ingestor/.*[.]go$'; then
+            echo "ingestor=true" >> "$GITHUB_OUTPUT"
+            echo "-> ingestor Go files changed, race detector runs"
+          else
+            echo "ingestor=false" >> "$GITHUB_OUTPUT"
+            echo "-> no ingestor Go changes, race detector skips"
+          fi
+
+  # ───────────────────────────────────────────────────────────────
+  # 1a. Race detector (ingestor) — its own job on purpose
+  # ───────────────────────────────────────────────────────────────
+  # Runs beside "Go Build & Test" rather than inside it, so its ten-odd
+  # minutes overlap the E2E job instead of extending the critical path, and
+  # only when ingestor Go files changed. A frontend or documentation PR cannot
+  # introduce a data race here, and paying for the check on every PR is what
+  # gets a check switched off again.
+  #
+  # The server has -race in its own step already; this closes the same gap for
+  # the ingestor, which carries an atomic.Pointer snapshot (the region key
+  # set) whose safety is an argument until something checks it.
+  race-test:
+    name: "🏁 Race detector (ingestor)"
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.ingestor == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Go 1.27
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.27'
+          cache-dependency-path: cmd/ingestor/go.sum
+
+      - name: go test -race
+        run: |
+          set -e -o pipefail
+          cd cmd/ingestor
+          go test -timeout 30m -race ./...
 
   # ───────────────────────────────────────────────────────────────
   # 1. Go Build & Test

--- a/cmd/ingestor/multibyte_persist_helpers_test.go
+++ b/cmd/ingestor/multibyte_persist_helpers_test.go
@@ -5,15 +5,16 @@ import (
 	"database/sql"
 	"log"
 	"strings"
+	"sync"
 	"testing"
 )
 
 // captureLogs redirects the standard logger to a buffer for the
 // duration of the test and returns the buffer. Restores the previous
 // writer when the test ends.
-func captureLogs(t *testing.T) *bytes.Buffer {
+func captureLogs(t *testing.T) *syncBuffer {
 	t.Helper()
-	buf := &bytes.Buffer{}
+	buf := &syncBuffer{}
 	prevWriter := log.Writer()
 	prevFlags := log.Flags()
 	log.SetOutput(buf)
@@ -24,9 +25,32 @@ func captureLogs(t *testing.T) *bytes.Buffer {
 	return buf
 }
 
+// syncBuffer is a bytes.Buffer that may be read while a background goroutine
+// is still logging into it. log.Logger serialises its own writes, but the test
+// reading buf.String() sits outside that lock, and RunAsyncMigration keeps
+// logging after the call that started it returns. Without this the read and
+// the write race, which is a real data race and not a test artefact: it can
+// panic on a buffer grow, not merely trip -race.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 // logContains reports whether the captured log buffer contains substr
 // (case-insensitive).
-func logContains(buf *bytes.Buffer, substr string) bool {
+func logContains(buf *syncBuffer, substr string) bool {
 	return strings.Contains(strings.ToLower(buf.String()), strings.ToLower(substr))
 }
 

--- a/cmd/ingestor/stats_file.go
+++ b/cmd/ingestor/stats_file.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/meshcore-analyzer/perfio"
@@ -240,11 +241,20 @@ func procIORate(prev, cur procIOSnapshot, stamp string) *PerfIOSample {
 // The stats file path is resolved via statsFilePath() once at writer-loop
 // start; the env var (CORESCOPE_INGESTOR_STATS) is only re-read on process
 // restart, not per tick.
-func StartStatsFileWriter(s *Store, interval time.Duration) {
+// The returned stop function ends the writer goroutine and returns once it has
+// exited. Production ignores it and runs for the process lifetime; tests must
+// call it, because this goroutine reads package-level hooks (readProcSelfIOFn)
+// that a later test may replace, and a writer left running past its own test
+// races with whoever runs next. It is safe to call more than once.
+func StartStatsFileWriter(s *Store, interval time.Duration) (stop func()) {
 	if interval <= 0 {
 		interval = time.Second
 	}
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	var once sync.Once
 	go func() {
+		defer close(stopped)
 		t := time.NewTicker(interval)
 		defer t.Stop()
 		path := statsFilePath()
@@ -257,7 +267,12 @@ func StartStatsFileWriter(s *Store, interval time.Duration) {
 		// The buffer grows once and stays.
 		var buf bytes.Buffer
 		enc := json.NewEncoder(&buf)
-		for range t.C {
+		for {
+			select {
+			case <-done:
+				return
+			case <-t.C:
+			}
 			// Capture time.Now() ONCE per tick (Carmack must-fix #5).
 			// Both snapshot.SampledAt and procIO.SampledAt MUST share the
 			// same string so the freshness guard isn't validating one
@@ -305,4 +320,8 @@ func StartStatsFileWriter(s *Store, interval time.Duration) {
 			}
 		}
 	}()
+	return func() {
+		once.Do(func() { close(done) })
+		<-stopped
+	}
 }

--- a/cmd/ingestor/stats_file_test.go
+++ b/cmd/ingestor/stats_file_test.go
@@ -56,7 +56,7 @@ func TestStatsFileWriter_PublishesProcIO(t *testing.T) {
 	}
 	defer store.Close()
 
-	StartStatsFileWriter(store, 50*time.Millisecond)
+	t.Cleanup(StartStatsFileWriter(store, 50*time.Millisecond))
 
 	// Wait for at least 2 ticks so the writer has had a chance to populate
 	// procIO rates from a delta.

--- a/cmd/ingestor/stats_file_timestamp_test.go
+++ b/cmd/ingestor/stats_file_timestamp_test.go
@@ -69,7 +69,7 @@ func TestStatsFileWriter_SampledAtMatchesProcIOSampledAt(t *testing.T) {
 		}
 	}
 
-	StartStatsFileWriter(store, 50*time.Millisecond)
+	t.Cleanup(StartStatsFileWriter(store, 50*time.Millisecond))
 
 	// Wait for the file to land with a populated procIO block.
 	deadline := time.Now().Add(3 * time.Second)


### PR DESCRIPTION
`go test -race ./...` on `cmd/ingestor` reports **six data races** on master. None is in production logic. All six come from test helpers that outlive the test that started them, which is why the detector blames whichever test happens to be running: two different tests failed on two consecutive runs of the same code.

## What was racing

**`StartStatsFileWriter` had no way to stop.** Two tests start it at a 50ms interval, and its goroutine then runs for the rest of the process. It reads the package-level `readProcSelfIOFn` hook, which a later test replaces to inject a fake, so the write and the read race. The same leak explains the stray log lines about writing stats into temp directories that were already cleaned up.

It now returns a stop function that closes the goroutine and waits for it to exit. Production ignores the return value and runs for the process lifetime exactly as before; the two tests call it through `t.Cleanup`.

**The migration test read a log buffer while a goroutine wrote to it.** `log.Logger` serialises its own writes, but `logContains` read `buf.String()` outside that lock while `RunAsyncMigration` kept logging after the call that started it had returned. The capture helper now uses a mutex-protected buffer.

That one is worth calling a real race rather than a test artefact: a concurrent read during a buffer grow can panic outright with "concurrent map read and map write"-class behaviour, not merely trip `-race`.

## Measured

`go test -race ./...` on linux/arm64 under go1.27.1: **exit 0, zero races, 704s**.

## The CI job, and why it is shaped this way

The server has had `-race` since #1208. This closes the same gap for the ingestor, which carries an `atomic.Pointer` snapshot (the region key set from #1989) whose safety has been an argument rather than a measurement.

Two deliberate choices, because a check that costs too much gets switched off:

- **Its own job, not a step inside "Go Build & Test".** Appending `-race` there puts its ten-odd minutes on the critical path, taking the pipeline from roughly 20 minutes to roughly 32. As a separate job it runs beside the E2E job (15-17 minutes) and hides inside that window.
- **Only when `cmd/ingestor/**.go` changed**, decided by the existing change-scope job, which already gates the heavy jobs on documentation-only PRs. A frontend or docs PR cannot introduce a data race in the ingestor. Pushes to master always run it, as they already do for `code`.

Nothing `needs:` the new job. Adding it to `build-and-publish` would mean a skipped race job skips everything downstream, which is the opposite of what a conditional check should do. It reports as its own check; whether that blocks a merge is a repository setting rather than workflow logic.

## Scope

Test helpers, one production signature (`StartStatsFileWriter` now returns a stop function), and the workflow. No change to what the ingestor does at runtime.