### PR TITLE
feat(ingestor): keep the scope-match tally across restarts

### DIFF
--- a/cmd/ingestor/db.go
+++ b/cmd/ingestor/db.go
@@ -159,6 +159,13 @@ func OpenStoreWithInterval(dbPath string, sampleIntervalSec int) (*Store, error)
 		return nil, fmt.Errorf("preparing statements: %w", err)
 	}
 
+	// Continue the scope-match tally from where the previous process left
+	// off. Not fatal: a tally that cannot be read costs an observability
+	// number, and refusing to ingest over it would be the worse trade.
+	if err := s.LoadScopeMatchTotals(); err != nil {
+		log.Printf("[regions] restoring scope-match tally: %v", err)
+	}
+
 	// Schedule async migrations. These must NOT block boot. See
 	// async_migration.go for the convention.
 	// PREFLIGHT: async=true reason="composite index build on observations (1.9M+ rows in prod) — converted from sync after v3.8.3"
@@ -226,6 +233,16 @@ func applySchema(db *sql.DB) error {
 			battery_mv INTEGER,
 			temperature_c REAL,
 			foreign_advert INTEGER DEFAULT 0
+		);
+
+		CREATE TABLE IF NOT EXISTS scope_match_totals (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
+			since_unix INTEGER NOT NULL,
+			unique_matches INTEGER NOT NULL,
+			explicit_over_derived INTEGER NOT NULL,
+			ambiguous INTEGER NOT NULL,
+			none_matches INTEGER NOT NULL,
+			updated_unix INTEGER NOT NULL
 		);
 
 		CREATE TABLE IF NOT EXISTS observers (

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -485,6 +485,13 @@ func main() {
 	go func() {
 		for range statsTicker.C {
 			store.LogStats()
+			// Persist the scope-match tally on the stats cadence rather
+			// than the region-refresh one: the counters are recorded for
+			// every transport-scoped packet, including on instances that
+			// never enable autoRegionKeys and so never run that ticker.
+			if err := store.SaveScopeMatchTotals(); err != nil {
+				log.Printf("[regions] saving scope-match tally: %v", err)
+			}
 			if d := ingestBuffer.Dropped(); d > 0 || ingestBuffer.Pending() > 0 {
 				log.Printf("[ingest-buffer] pending=%d dropped_total=%d", ingestBuffer.Pending(), d)
 			}
@@ -559,6 +566,12 @@ func main() {
 	pruneQueueTicker.Stop()
 	walCheckpointTicker.Stop()
 	stopWatchdog()
+	// A deploy is a SIGTERM, which is exactly the case that used to lose
+	// the tally: save before the process goes away rather than leaving up
+	// to 5 minutes of counting to the next tick that will not come.
+	if err := store.SaveScopeMatchTotals(); err != nil {
+		log.Printf("[regions] saving scope-match tally: %v", err)
+	}
 	store.LogStats() // final stats on shutdown
 	for _, c := range clients {
 		c.Disconnect(5000) // 5s to allow in-flight messages to drain

--- a/cmd/ingestor/region_keys.go
+++ b/cmd/ingestor/region_keys.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync/atomic"
+	"time"
 )
 
 // declaredRegionStat is one region name as reported over RF, with the two
@@ -402,6 +403,10 @@ var scopeMatchCounters struct {
 	explicitOverDerived atomic.Int64
 	ambiguous           atomic.Int64
 	none                atomic.Int64
+	// sinceUnix is when this tally started counting, carried across
+	// restarts with the counters themselves (scope_match_tally.go). A
+	// ratio without its window is not a measurement.
+	sinceUnix atomic.Int64
 }
 
 // recordScopeMatch tallies one decision and logs the interesting ones. Unique
@@ -426,7 +431,8 @@ func recordScopeMatch(m scopeMatch) {
 // ticker so the numbers arrive on the same cadence as the key-set changes that
 // move them.
 func logScopeMatchCounters() {
-	log.Printf("[regions] scope matches: unique=%d explicit-over-derived=%d ambiguous=%d none=%d",
+	log.Printf("[regions] scope matches since %s: unique=%d explicit-over-derived=%d ambiguous=%d none=%d",
+		time.Unix(scopeMatchCounters.sinceUnix.Load(), 0).UTC().Format(time.RFC3339),
 		scopeMatchCounters.unique.Load(), scopeMatchCounters.explicitOverDerived.Load(),
 		scopeMatchCounters.ambiguous.Load(), scopeMatchCounters.none.Load())
 }

--- a/cmd/ingestor/scope_match_tally.go
+++ b/cmd/ingestor/scope_match_tally.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"time"
+)
+
+// The scope-match tally lives in scopeMatchCounters, four atomics in this
+// process and nowhere else. Every restart — a deploy, a crash, an operator
+// bouncing the container — sets them back to zero and takes the container's
+// log with it, so the previous count is not recoverable afterwards. That is
+// how a finished 24h ambiguity measurement was lost.
+//
+// The numbers only say something over days: "ambiguous is 0.4% of matches"
+// needs a denominator large enough to be stable, and the decision they gate
+// (whether a collision tie-break is worth building) is not one to take on an
+// hour of traffic. So they have to outlive the process doing the counting.
+//
+// scope_match_totals is one row. The ingestor reads it into the counters at
+// startup and writes them back periodically and on shutdown, which makes the
+// tally cumulative since `since_unix` instead of since boot. It is deliberately
+// NOT in internal/dbschema: the server neither reads this table nor detects it,
+// and putting it in AssertReady would make an old DB without the table fail the
+// server's startup check for data the server never looks at.
+
+const scopeMatchTotalsSchema = `
+	CREATE TABLE IF NOT EXISTS scope_match_totals (
+		id INTEGER PRIMARY KEY CHECK (id = 1),
+		since_unix INTEGER NOT NULL,
+		unique_matches INTEGER NOT NULL,
+		explicit_over_derived INTEGER NOT NULL,
+		ambiguous INTEGER NOT NULL,
+		none_matches INTEGER NOT NULL,
+		updated_unix INTEGER NOT NULL
+	)`
+
+// LoadScopeMatchTotals seeds the in-process counters from the stored row so
+// counting continues where the previous process stopped. On a DB that has no
+// row yet it anchors `since` at now and stores the zeroes, so the very first
+// window has a start time too — without it, a tally read after one restart
+// would have no honest denominator.
+func (s *Store) LoadScopeMatchTotals() error {
+	var since, uniq, explicit, ambiguous, none int64
+	err := s.db.QueryRow(`
+		SELECT since_unix, unique_matches, explicit_over_derived, ambiguous, none_matches
+		FROM scope_match_totals WHERE id = 1`).Scan(&since, &uniq, &explicit, &ambiguous, &none)
+	if errors.Is(err, sql.ErrNoRows) {
+		scopeMatchCounters.sinceUnix.Store(time.Now().Unix())
+		return s.SaveScopeMatchTotals()
+	}
+	if err != nil {
+		return err
+	}
+	scopeMatchCounters.sinceUnix.Store(since)
+	scopeMatchCounters.unique.Store(uniq)
+	scopeMatchCounters.explicitOverDerived.Store(explicit)
+	scopeMatchCounters.ambiguous.Store(ambiguous)
+	scopeMatchCounters.none.Store(none)
+	return nil
+}
+
+// SaveScopeMatchTotals writes the current counters to the single row. Each
+// atomic is loaded independently, so a save taken under live traffic can miss
+// a match that lands mid-write; the next save picks it up. The tally is a
+// long-window ratio, not an audit trail.
+func (s *Store) SaveScopeMatchTotals() error {
+	_, err := s.db.Exec(`
+		INSERT INTO scope_match_totals
+			(id, since_unix, unique_matches, explicit_over_derived, ambiguous, none_matches, updated_unix)
+		VALUES (1, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			since_unix = excluded.since_unix,
+			unique_matches = excluded.unique_matches,
+			explicit_over_derived = excluded.explicit_over_derived,
+			ambiguous = excluded.ambiguous,
+			none_matches = excluded.none_matches,
+			updated_unix = excluded.updated_unix`,
+		scopeMatchCounters.sinceUnix.Load(),
+		scopeMatchCounters.unique.Load(),
+		scopeMatchCounters.explicitOverDerived.Load(),
+		scopeMatchCounters.ambiguous.Load(),
+		scopeMatchCounters.none.Load(),
+		time.Now().Unix())
+	return err
+}

--- a/cmd/ingestor/scope_match_tally_test.go
+++ b/cmd/ingestor/scope_match_tally_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// resetScopeMatchCounters zeroes the package-level tally and puts it back
+// afterwards. The counters are global and OpenStore restores them from the
+// DB, so every test here has to start from a known state; no test in this
+// package calls t.Parallel, which is what makes that safe.
+func resetScopeMatchCounters(t *testing.T) {
+	t.Helper()
+	prevUnique := scopeMatchCounters.unique.Load()
+	prevExplicit := scopeMatchCounters.explicitOverDerived.Load()
+	prevAmbiguous := scopeMatchCounters.ambiguous.Load()
+	prevNone := scopeMatchCounters.none.Load()
+	prevSince := scopeMatchCounters.sinceUnix.Load()
+	t.Cleanup(func() {
+		scopeMatchCounters.unique.Store(prevUnique)
+		scopeMatchCounters.explicitOverDerived.Store(prevExplicit)
+		scopeMatchCounters.ambiguous.Store(prevAmbiguous)
+		scopeMatchCounters.none.Store(prevNone)
+		scopeMatchCounters.sinceUnix.Store(prevSince)
+	})
+	scopeMatchCounters.unique.Store(0)
+	scopeMatchCounters.explicitOverDerived.Store(0)
+	scopeMatchCounters.ambiguous.Store(0)
+	scopeMatchCounters.none.Store(0)
+	scopeMatchCounters.sinceUnix.Store(0)
+}
+
+// TestScopeMatchTallySurvivesReopen is the whole point of the table: a
+// restart used to reset the tally to zero and delete the container log that
+// held the previous number, so a measurement in progress was unrecoverable.
+func TestScopeMatchTallySurvivesReopen(t *testing.T) {
+	resetScopeMatchCounters(t)
+	dbPath := t.TempDir() + "/tally.db"
+
+	s, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	since := scopeMatchCounters.sinceUnix.Load()
+	scopeMatchCounters.unique.Store(19692)
+	scopeMatchCounters.ambiguous.Store(80)
+	scopeMatchCounters.explicitOverDerived.Store(3)
+	scopeMatchCounters.none.Store(41)
+	if err := s.SaveScopeMatchTotals(); err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	// A new process starts with zeroed counters.
+	scopeMatchCounters.unique.Store(0)
+	scopeMatchCounters.ambiguous.Store(0)
+	scopeMatchCounters.explicitOverDerived.Store(0)
+	scopeMatchCounters.none.Store(0)
+	scopeMatchCounters.sinceUnix.Store(0)
+
+	s2, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s2.Close()
+
+	if got := scopeMatchCounters.unique.Load(); got != 19692 {
+		t.Errorf("unique = %d, want 19692 restored from the previous run", got)
+	}
+	if got := scopeMatchCounters.ambiguous.Load(); got != 80 {
+		t.Errorf("ambiguous = %d, want 80 restored from the previous run", got)
+	}
+	if got := scopeMatchCounters.explicitOverDerived.Load(); got != 3 {
+		t.Errorf("explicitOverDerived = %d, want 3", got)
+	}
+	if got := scopeMatchCounters.none.Load(); got != 41 {
+		t.Errorf("none = %d, want 41", got)
+	}
+	if got := scopeMatchCounters.sinceUnix.Load(); got != since {
+		t.Errorf("sinceUnix = %d, want %d — the window start must carry across the restart, or the ratio has no denominator", got, since)
+	}
+}
+
+// TestScopeMatchTallyAnchorsSinceOnFirstOpen pins that a DB with no row gets
+// one immediately. Without it the first window's start would only be written
+// once something had already been counted, and a tally read after one restart
+// would report a rate over an unknown period.
+func TestScopeMatchTallyAnchorsSinceOnFirstOpen(t *testing.T) {
+	resetScopeMatchCounters(t)
+	before := time.Now().Unix()
+
+	s, err := OpenStore(t.TempDir() + "/tally.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	since := scopeMatchCounters.sinceUnix.Load()
+	if since < before || since > time.Now().Unix() {
+		t.Errorf("sinceUnix = %d, want a stamp between %d and now", since, before)
+	}
+	var rows int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM scope_match_totals`).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 {
+		t.Errorf("scope_match_totals rows = %d, want exactly 1 — the table holds a single running total", rows)
+	}
+}
+
+// TestScopeMatchTallyContinuesAfterRestore checks the restored values are a
+// starting point and not a ceiling: recording after a restart adds to the
+// carried total rather than counting from zero again.
+func TestScopeMatchTallyContinuesAfterRestore(t *testing.T) {
+	resetScopeMatchCounters(t)
+	dbPath := t.TempDir() + "/tally.db"
+
+	s, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scopeMatchCounters.unique.Store(10)
+	scopeMatchCounters.ambiguous.Store(2)
+	if err := s.SaveScopeMatchTotals(); err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	s2, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s2.Close()
+
+	recordScopeMatch(scopeMatch{Reason: scopeReasonUnique, Name: "#be"})
+	recordScopeMatch(scopeMatch{Reason: scopeReasonAmbiguous, Candidates: []string{"#be", "#nl"}})
+	if err := s2.SaveScopeMatchTotals(); err != nil {
+		t.Fatal(err)
+	}
+
+	var uniq, ambiguous int64
+	if err := s2.db.QueryRow(`SELECT unique_matches, ambiguous FROM scope_match_totals WHERE id = 1`).Scan(&uniq, &ambiguous); err != nil {
+		t.Fatal(err)
+	}
+	if uniq != 11 || ambiguous != 3 {
+		t.Errorf("stored unique=%d ambiguous=%d, want 11 and 3 — counting must resume on top of the restored totals", uniq, ambiguous)
+	}
+}
+
+// TestScopeMatchTallySaveIsIdempotent pins the single-row upsert: repeated
+// saves must update the row, never accumulate rows. The CHECK(id = 1) makes a
+// second row impossible, and this fails loudly if the INSERT is ever changed
+// to one without the conflict clause.
+func TestScopeMatchTallySaveIsIdempotent(t *testing.T) {
+	resetScopeMatchCounters(t)
+
+	s, err := OpenStore(t.TempDir() + "/tally.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	for i := 0; i < 3; i++ {
+		scopeMatchCounters.unique.Add(1)
+		if err := s.SaveScopeMatchTotals(); err != nil {
+			t.Fatalf("save %d: %v", i, err)
+		}
+	}
+
+	var rows, uniq int64
+	if err := s.db.QueryRow(`SELECT COUNT(*), MAX(unique_matches) FROM scope_match_totals`).Scan(&rows, &uniq); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 || uniq != 3 {
+		t.Errorf("rows=%d unique=%d, want 1 row holding 3", rows, uniq)
+	}
+}


### PR DESCRIPTION
## What

`scopeMatchCounters` (unique / explicit-over-derived / ambiguous / none) lives only in the ingestor process, and the only way to read it is the periodic log line. A restart zeroes the counters, and recreating the container removes that log with it, so a measurement in progress cannot be recovered afterwards.

That happened here on 2026-09-10: a 24h ambiguity measurement completed, two deploys followed before it was read, and nothing on disk held the number. `/var/lib/docker/containers/*/*-json.log` had no earlier copy.

The tally gates a real decision (whether the collision tie-break from the `autoRegionKeys` design is worth building), and that needs days of traffic, so it has to survive the process counting it.

## How

A single-row table, `scope_match_totals`:

- `OpenStore` restores the counters from it, so counting continues instead of restarting.
- The 5-minute stats ticker writes them back, and so does the shutdown path, which is what a deploy triggers.
- `since_unix` carries the window start across restarts, so the ratio keeps a denominator. The periodic log line now prints it.

Saving rides the **stats** ticker, not the region-refresh ticker: matches are recorded for every transport-scoped packet, including on instances that never enable `autoRegionKeys` and so never start the refresh loop.

The table is **not** in `internal/dbschema` on purpose. The server neither reads nor PRAGMA-detects it; putting it in `AssertReady` would make an older DB fail the server's startup check over data the server never looks at.

A failed restore is logged and ingestion continues. Losing an observability counter is not a reason to stop ingesting.

## Tests

Four, all in `cmd/ingestor/scope_match_tally_test.go`:

- totals and `since_unix` restored across a close/reopen
- a fresh DB gets its anchor row immediately, so the first window has a start time
- recording after a restore adds to the carried total instead of counting from zero
- repeated saves keep exactly one row

Full `cmd/ingestor` suite green locally except `TestWriteStatsAtomic_SymlinkAtDestIsReplaced`, which fails on Windows only (`os.Symlink` needs a privilege this account lacks) and predates this branch. `go vet` and `gofmt` clean. The race detector was not run locally (no cgo toolchain here); the `race-test` job covers it, since this branch touches `cmd/ingestor`.

## Not done

No UI or API surface for the tally. It is still read from the log line or straight from the table.