### PR TITLE
test(ingestor): join the watchdog loop goroutine instead of only asking it to stop

### DIFF
--- a/cmd/ingestor/mqtt_watchdog_1749_test.go
+++ b/cmd/ingestor/mqtt_watchdog_1749_test.go
@@ -58,15 +58,8 @@ func TestMQTTStallWatchdog_EscalateOnPersistentDisconnect_1749(t *testing.T) {
 		t.Fatalf("setup: %v", err)
 	}
 
-	tick := make(chan time.Time)
-	done := make(chan struct{})
-	defer close(done)
-
-	exited := make(chan struct{})
-	go func() {
-		runLivenessWatchdogLoop(tick, done, threshold, func(args ...any) {})
-		close(exited)
-	}()
+	tick, stopLoop := startWatchdogTestLoop(t, threshold, func(args ...any) {})
+	defer stopLoop()
 
 	// Feed ticks spanning > (multiplier × threshold) of wall clock so
 	// the escalation path fires. We control the `now` parameter by
@@ -114,10 +107,8 @@ func TestMQTTStallWatchdog_DisconnectedEscalationThrottled_1749(t *testing.T) {
 		t.Fatalf("setup: %v", err)
 	}
 
-	tick := make(chan time.Time)
-	done := make(chan struct{})
-	defer close(done)
-	go runLivenessWatchdogLoop(tick, done, threshold, func(args ...any) {})
+	tick, stopLoop := startWatchdogTestLoop(t, threshold, func(args ...any) {})
+	defer stopLoop()
 
 	base := time.Now()
 	// Pre-stamp DisconnectedSinceUnix so that the first tick is
@@ -259,10 +250,8 @@ func TestMQTTStallWatchdog_LastTickUnixExposed_1749(t *testing.T) {
 		watchdogLastTickUnix.Store(before)
 	})
 
-	tick := make(chan time.Time)
-	done := make(chan struct{})
-	defer close(done)
-	go runLivenessWatchdogLoop(tick, done, time.Minute, func(args ...any) {})
+	tick, stopLoop := startWatchdogTestLoop(t, time.Minute, func(args ...any) {})
+	defer stopLoop()
 
 	stamp := time.Now().Add(48 * time.Hour) // guaranteed > before
 	select {

--- a/cmd/ingestor/mqtt_watchdog_1810_test.go
+++ b/cmd/ingestor/mqtt_watchdog_1810_test.go
@@ -212,10 +212,8 @@ func TestWatchdog_EscalationWarnThrottled_1810(t *testing.T) {
 		}
 	}
 
-	tick := make(chan time.Time)
-	done := make(chan struct{})
-	defer close(done)
-	go runLivenessWatchdogLoop(tick, done, threshold, emit)
+	tick, stopLoop := startWatchdogTestLoop(t, threshold, emit)
+	defer stopLoop()
 
 	base := time.Now()
 	// First tick: stamps DisconnectedSinceUnix (no escalation yet).

--- a/cmd/ingestor/mqtt_watchdog_testhelpers_test.go
+++ b/cmd/ingestor/mqtt_watchdog_testhelpers_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -43,5 +44,33 @@ func sendTickOrFail(t *testing.T, tick chan<- time.Time, stamp time.Time, timeou
 	case tick <- stamp:
 	case <-time.After(timeout):
 		t.Fatalf("%s: tick blocked after %s — loop dead?", label, timeout)
+	}
+}
+
+// startWatchdogTestLoop is setupWatchdogTestLoop for the common case: a test
+// that wants the loop running for its own duration and nothing more. The
+// returned stop closes done AND waits for the loop goroutine to return. It is
+// safe to call more than once.
+//
+// Waiting is the part that must not be skipped. Closing done only asks the
+// loop to stop; the goroutine can still be inside a scan, and that scan walks
+// the package-level livenessRegistry. The next test registers its own source
+// there, so a loop that has not returned yet will process that source on a
+// tick carrying the previous test's fabricated clock.
+//
+// That is measured, not theoretical. With four call sites closing done and
+// walking away, TestMQTTStallWatchdog_DisconnectedEscalationThrottled_1749
+// failed 2 to 3 times per 20 runs of the watchdog tests and never once in 50
+// runs on its own. Debug tracing showed two loops reaching maybeForceReconnect
+// for the same source with tick clocks 420s apart, both reading
+// LastForceReconnectUnix as 0 before either wrote it, so the throttle the test
+// asserts on let both through.
+func startWatchdogTestLoop(t *testing.T, threshold time.Duration, emit func(...any)) (tick chan time.Time, stop func()) {
+	t.Helper()
+	tick, done, exited := setupWatchdogTestLoop(t, threshold, emit)
+	var once sync.Once
+	return tick, func() {
+		once.Do(func() { close(done) })
+		<-exited
 	}
 }


### PR DESCRIPTION
## The symptom

`TestMQTTStallWatchdog_DisconnectedEscalationThrottled_1749` fails with `escalation must be throttled within 1m0s; got 2 invocations`. It blocked an unrelated PR today.

| run | failures |
|---|---|
| `-run TestMQTTStallWatchdog -count=20`, this branch's base | 3 / 20 |
| same on clean `master` | 2 / 20 |
| `-run ...Throttled_1749$ -count=50` alone | 0 / 50 |

Failing only inside the suite and never alone points at cross-test state, not at the assertion.

## The cause

Four call sites started `runLivenessWatchdogLoop` and finished with `defer close(done)`. Closing `done` asks the loop to stop. It does not wait for it, and the loop's per-tick scan walks the package-level `livenessRegistry`, which by then contains the next test's source.

Temporary tracing in `maybeForceReconnect` caught it happening:

```
DBG tag=throttle-escalate now=1789076161.940049000 lastForce=0 caller=mqtt_watchdog.go:663
DBG tag=throttle-escalate now=1789076581.939372300 lastForce=0 caller=mqtt_watchdog.go:663
```

Same source, tick clocks 420s apart, and **both read `LastForceReconnectUnix` as 0** before either wrote it. The second `now` carries the nanosecond fraction of the `silent-paho` test's fabricated clock, so that test's loop was still alive and processing our source. Two loops, one check-then-act throttle, two invocations.

## The fix

`startWatchdogTestLoop` wraps the existing `setupWatchdogTestLoop` and returns a `stop` that closes `done` **and waits for the goroutine to return**. The four leaking sites now use it. The other five already did close-then-wait by hand and are untouched.

Test-only change; no production code is modified.

## Evidence

- **0 failures in 120 runs** of `-run TestMQTTStallWatchdog` on this branch, against 4 in 45 on the base.
- Full `cmd/ingestor` suite green except `TestWriteStatsAtomic_SymlinkAtDestIsReplaced`, which fails on Windows only (`os.Symlink` needs a privilege this account lacks) and predates this branch.
- `go vet` and `gofmt` clean. The race detector was not run locally (no cgo toolchain here); the `race-test` job covers it since this touches `cmd/ingestor`.

## One thing deliberately left alone

`maybeForceReconnect`'s throttle is a load-then-store, not a compare-and-swap. It is only safe because production runs exactly one watchdog loop, which after this change is also true of the tests. If that invariant should not be load-bearing, a CAS is three lines, but it is a production change and does not belong in a test fix.