### PR TITLE
feat(ingestor): log a throttled warning when the IATA whitelist drops a region

### DIFF
--- a/cmd/ingestor/config.go
+++ b/cmd/ingestor/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/meshcore-analyzer/dbconfig"
 	"github.com/meshcore-analyzer/geofilter"
@@ -76,6 +77,14 @@ type Config struct {
 	// obsIATAWhitelistCached is the lazily-built uppercase set for O(1) lookups.
 	obsIATAWhitelistCached map[string]bool
 	obsIATAWhitelistOnce   sync.Once
+
+	// IATAWarnIntervalSec throttles the one-line-per-region warning emitted when
+	// ObserverIATAWhitelist rejects a region. 0 => defaultIATAWarnIntervalSec.
+	IATAWarnIntervalSec int `json:"iataWarnIntervalSec,omitempty"`
+
+	// iataWarnLast tracks when each dropped region was last logged.
+	iataWarnMu   sync.Mutex
+	iataWarnLast map[string]time.Time
 
 	// ObserverBlacklist is a list of observer public keys to drop at ingest.
 	// Messages from blacklisted observers are silently discarded â€” no DB writes,
@@ -355,6 +364,51 @@ func (c *Config) IsObserverIATAAllowed(iata string) bool {
 		c.obsIATAWhitelistCached = m
 	})
 	return c.obsIATAWhitelistCached[strings.ToUpper(strings.TrimSpace(iata))]
+}
+
+// defaultIATAWarnIntervalSec is the re-log interval for whitelist drops (6h).
+const defaultIATAWarnIntervalSec = 21600
+
+// IATAWarnInterval returns how often a dropped region is re-logged.
+func (c *Config) IATAWarnInterval() time.Duration {
+	if c == nil || c.IATAWarnIntervalSec <= 0 {
+		return defaultIATAWarnIntervalSec * time.Second
+	}
+	return time.Duration(c.IATAWarnIntervalSec) * time.Second
+}
+
+// ShouldWarnIATADrop reports whether a whitelist drop for this region should be
+// logged now, recording the decision when it returns true.
+//
+// Logging every dropped message is not an option: a foreign feed runs to
+// thousands of messages a day and would flood the container log. But dropping
+// in silence is worse — an allow-list fails in the dangerous direction, where a
+// legitimate but unlisted region simply vanishes with nothing to show for it.
+// So: one line per region, re-logged at most every IATAWarnInterval for as long
+// as that region keeps arriving. The re-log is deliberate — a strict log-once
+// would emit a single edge event that any scrape window eventually rolls past,
+// leaving an actively-dropping region looking identical to a healthy one.
+func (c *Config) ShouldWarnIATADrop(iata string) bool {
+	if c == nil {
+		return false
+	}
+	code := strings.ToUpper(strings.TrimSpace(iata))
+	if code == "" {
+		return false
+	}
+	interval := c.IATAWarnInterval()
+	now := time.Now()
+
+	c.iataWarnMu.Lock()
+	defer c.iataWarnMu.Unlock()
+	if last, ok := c.iataWarnLast[code]; ok && now.Sub(last) < interval {
+		return false
+	}
+	if c.iataWarnLast == nil {
+		c.iataWarnLast = make(map[string]time.Time)
+	}
+	c.iataWarnLast[code] = now
+	return true
 }
 
 // LoadConfig reads configuration from a JSON file, with env var overrides.

--- a/cmd/ingestor/iata_drop_warn_test.go
+++ b/cmd/ingestor/iata_drop_warn_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIngestorIATAWhitelistGate(t *testing.T) {
+	// Empty whitelist: the facility stays inert, everything passes.
+	open := &Config{}
+	for _, code := range []string{"SJC", "PHL", "", "zzz"} {
+		if !open.IsObserverIATAAllowed(code) {
+			t.Errorf("empty whitelist should allow %q", code)
+		}
+	}
+
+	cfg := &Config{ObserverIATAWhitelist: []string{"SJC", "oak", " MRY "}}
+	tests := []struct {
+		iata string
+		want bool
+	}{
+		{"SJC", true},
+		{"sjc", true},
+		{"OAK", true},
+		{"MRY", true},
+		{" mry ", true},
+		{"PHL", false},
+		{"MCO", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := cfg.IsObserverIATAAllowed(tt.iata); got != tt.want {
+			t.Errorf("IsObserverIATAAllowed(%q) = %v, want %v", tt.iata, got, tt.want)
+		}
+	}
+}
+
+func TestIngestorIATAWarnInterval(t *testing.T) {
+	if got := (&Config{}).IATAWarnInterval(); got != 6*time.Hour {
+		t.Errorf("default interval = %v, want 6h", got)
+	}
+	if got := (&Config{IATAWarnIntervalSec: 90}).IATAWarnInterval(); got != 90*time.Second {
+		t.Errorf("configured interval = %v, want 90s", got)
+	}
+	// Negative/zero fall back to the default rather than logging every message.
+	if got := (&Config{IATAWarnIntervalSec: -5}).IATAWarnInterval(); got != 6*time.Hour {
+		t.Errorf("negative interval = %v, want 6h", got)
+	}
+}
+
+func TestIngestorShouldWarnIATADropThrottles(t *testing.T) {
+	cfg := &Config{ObserverIATAWhitelist: []string{"SJC"}, IATAWarnIntervalSec: 3600}
+
+	if !cfg.ShouldWarnIATADrop("PHL") {
+		t.Fatal("first drop for a region should warn")
+	}
+	if cfg.ShouldWarnIATADrop("PHL") {
+		t.Error("second drop inside the interval should be suppressed")
+	}
+	if cfg.ShouldWarnIATADrop("phl") {
+		t.Error("case variant should hit the same throttle bucket")
+	}
+	// A different region is tracked independently.
+	if !cfg.ShouldWarnIATADrop("MCO") {
+		t.Error("a distinct region should warn on its first drop")
+	}
+
+	// Once the interval elapses the region re-logs, so an ongoing drop stays
+	// visible to a scraper instead of decaying into silence.
+	cfg.iataWarnMu.Lock()
+	cfg.iataWarnLast["PHL"] = time.Now().Add(-2 * time.Hour)
+	cfg.iataWarnMu.Unlock()
+	if !cfg.ShouldWarnIATADrop("PHL") {
+		t.Error("region should re-log after the interval elapses")
+	}
+}
+
+func TestIngestorShouldWarnIATADropEdges(t *testing.T) {
+	var nilCfg *Config
+	if nilCfg.ShouldWarnIATADrop("PHL") {
+		t.Error("nil config should not warn")
+	}
+	cfg := &Config{}
+	if cfg.ShouldWarnIATADrop("   ") {
+		t.Error("blank region should not warn")
+	}
+}

--- a/cmd/ingestor/main.go
+++ b/cmd/ingestor/main.go
@@ -759,6 +759,14 @@ func handleMessage(store *Store, tag string, source MQTTSource, m mqtt.Message, 
 	// Global observer IATA whitelist: if configured, drop messages from observers
 	// in non-whitelisted IATA regions. Applies to ALL message types (status + packets).
 	if len(parts) > 1 && !cfg.IsObserverIATAAllowed(parts[1]) {
+		// Throttled to one line per region per cfg.IATAWarnInterval — see
+		// ShouldWarnIATADrop. Format matches the fleet's Python region filter so
+		// one scraper regex covers both.
+		if cfg.ShouldWarnIATADrop(parts[1]) {
+			code := strings.ToUpper(strings.TrimSpace(parts[1]))
+			log.Printf("MQTT [%s] [region-filter] dropping unknown region '%s' (not in observerIATAWhitelist) -- further messages from %s suppressed for %.0fh",
+				tag, code, code, cfg.IATAWarnInterval().Hours())
+		}
 		return
 	}
 


### PR DESCRIPTION
## Problem

`observerIATAWhitelist` drops non-whitelisted regions silently. An allow-list
fails in the dangerous direction: a legitimate but unlisted region vanishes with
nothing to show for it. A denylist at least lets the junk that gets through be
visible.

## Change

Emit one log line per dropped region, re-logged at most every
`iataWarnIntervalSec` (new optional config key, default 21600 = 6h) while that
region keeps arriving.

```
MQTT [gomesh] [region-filter] dropping unknown region 'XYZ' (not in observerIATAWhitelist) -- further messages from XYZ suppressed for 6h
```

Per-message logging is not an option: a foreign feed runs to thousands of
messages a day. The periodic re-log is deliberate. A strict log-once emits a
single edge event that any scrape window eventually rolls past, leaving an
actively-dropping region indistinguishable from a healthy one. The line format
is fixed and grep-friendly so a log scraper can key on it.

Behaviour with no whitelist configured is unchanged. No change to what is
accepted or dropped, only to what is logged.

## Perf

One mutex-guarded map lookup per dropped message (drops only, not the accept
path). Map is bounded by the number of distinct dropped region codes.

## Tests

`cmd/ingestor/iata_drop_warn_test.go`: throttle interval, default, edge cases
(first drop logs, repeat within interval does not, repeat after interval does,
regions independent). Existing IATA whitelist gate tests unchanged and passing.
`gofmt` and `go vet` clean.
