### PR TITLE
fix(packets): show browser-added channels in the channel filter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -229,6 +229,7 @@ jobs:
           node test-confidence-indicator.js
           node test-1659-analytics-warmup.js
           node test-channels-merge-1498-unit.js
+          node test-packets-local-channels.js
           node test-issue-1518-home-url.js
           node test-channel-decrypt-insecure-context.js
           node test-live-region-filter.js

--- a/public/packets.js
+++ b/public/packets.js
@@ -1042,6 +1042,92 @@
     else _docColMenuCloseHandler = handler;
   }
 
+  // --- Locally-added channels in the channel filter ---------------------
+  // Channels the operator adds in their own browser (Channels page → "Add
+  // channel") live only in localStorage — the keys never leave the client
+  // (channel-decrypt.js). The server therefore cannot decrypt their traffic
+  // and files it under the synthetic channel hash "enc_<HH>", which
+  // /api/channels omits. Result: a channel you just added is invisible in
+  // the packets channel picker.
+  //
+  // Fix: derive the same "enc_<HH>" value client-side from the stored key
+  // (SHA-256(key)[0], exactly what the ingestor writes) and offer those
+  // channels as extra options. /api/packets?channel=enc_<HH> already
+  // filters on that value server-side, so no backend change is needed.
+
+  /**
+   * Read the browser's stored channel keys and map each to the server-side
+   * channel-hash value its packets are stored under.
+   * Cost: one SHA-256 per stored key (a handful), once per page init.
+   * @returns {Promise<Array<{value:string,name:string,label:string}>>}
+   */
+  async function collectLocalChannels() {
+    const CD = window.ChannelDecrypt;
+    if (!CD || typeof CD.getStoredKeys !== 'function') return [];
+    let keys;
+    try { keys = CD.getStoredKeys() || {}; } catch (e) { return []; }
+    const out = [];
+    for (const name of Object.keys(keys)) {
+      const keyHex = keys[name];
+      if (!keyHex || typeof keyHex !== 'string') continue;
+      let hashByte;
+      try {
+        const keyBytes = CD.hexToBytes(keyHex);
+        if (!keyBytes || keyBytes.length !== 16) continue;
+        hashByte = await CD.computeChannelHash(keyBytes);
+      } catch (e) { continue; }
+      if (typeof hashByte !== 'number') continue;
+      const label = (typeof CD.getLabel === 'function' && CD.getLabel(name)) || name;
+      out.push({
+        // Uppercase 2-digit hex — matches cmd/ingestor/decoder.go ("%02X").
+        value: 'enc_' + hashByte.toString(16).padStart(2, '0').toUpperCase(),
+        name: name,
+        label: label
+      });
+    }
+    return out;
+  }
+
+  /**
+   * Merge the server channel list with locally-added ones into the two
+   * option groups the picker renders. Pure — unit-tested.
+   * A local channel is dropped when the server already exposes it (same
+   * hash value, or same name because the server holds the key too).
+   * @returns {{server: Array<{value:string,label:string}>, local: Array<{value:string,label:string}>}}
+   */
+  function buildChannelOptions(serverChannels, localChannels) {
+    const byLabel = (a, b) => {
+      const an = (a.label || '').toLowerCase();
+      const bn = (b.label || '').toLowerCase();
+      return an < bn ? -1 : an > bn ? 1 : 0;
+    };
+    const server = [];
+    const seenValues = new Set();
+    const seenNames = new Set();
+    for (const ch of serverChannels || []) {
+      const value = (ch && (ch.hash || ch.name)) || '';
+      if (!value || seenValues.has(value)) continue;
+      seenValues.add(value);
+      seenNames.add(String(ch.name || value).toLowerCase());
+      server.push({ value: value, label: ch.name || value });
+    }
+    const local = [];
+    for (const lc of localChannels || []) {
+      if (!lc || !lc.value) continue;
+      if (seenValues.has(lc.value)) continue;
+      if (seenNames.has(String(lc.name || '').toLowerCase())) continue;
+      seenValues.add(lc.value);
+      local.push({ value: lc.value, label: lc.label || lc.name });
+    }
+    return { server: server.sort(byLabel), local: local.sort(byLabel) };
+  }
+
+  // Exported for test-packets-local-channels.js (no DOM required).
+  if (typeof window !== 'undefined') {
+    window._packetsBuildChannelOptionsForTest = buildChannelOptions;
+    window._packetsCollectLocalChannelsForTest = collectLocalChannels;
+  }
+
   function renderTimestampCell(isoString) {
     if (typeof formatTimestampWithTooltip !== 'function' || typeof getTimestampMode !== 'function') {
       return escapeHtml(typeof timeAgo === 'function' ? timeAgo(isoString) : '—');
@@ -1815,31 +1901,37 @@
         opt.selected = true;
         channelSel.appendChild(opt);
       }
-      api('/channels').then(data => {
+      Promise.all([
+        api('/channels').catch(() => null),
+        collectLocalChannels()
+      ]).then(([data, localChannels]) => {
         const channels = (data && data.channels) || [];
         // Build options via DOM API: channel names are network-supplied
         // and must NOT be interpolated into innerHTML (XSS, #812).
         // Sort alphabetically (case-insensitive) for predictable picker order;
         // the API returns last-activity order which is unstable for a dropdown.
-        const sorted = channels.slice().sort((a, b) => {
-          const an = (a.name || a.hash || '').toLowerCase();
-          const bn = (b.name || b.hash || '').toLowerCase();
-          return an < bn ? -1 : an > bn ? 1 : 0;
-        });
+        const groups = buildChannelOptions(channels, localChannels);
         channelSel.textContent = '';
         const allOpt = document.createElement('option');
         allOpt.value = '';
         allOpt.textContent = 'All Channels';
         channelSel.appendChild(allOpt);
         let matched = false;
-        for (const ch of sorted) {
-          const v = ch.hash || ch.name || '';
-          if (!v) continue;
+        const addOption = (o, parent) => {
           const opt = document.createElement('option');
-          opt.value = v;
-          opt.textContent = ch.name || v;
-          if (v === filters.channel) { opt.selected = true; matched = true; }
-          channelSel.appendChild(opt);
+          opt.value = o.value;
+          opt.textContent = o.label;
+          if (o.value === filters.channel) { opt.selected = true; matched = true; }
+          parent.appendChild(opt);
+        };
+        for (const o of groups.server) addOption(o, channelSel);
+        // Browser-added channels the server can't see, grouped so it's
+        // obvious they come from keys stored in this browser only.
+        if (groups.local.length) {
+          const grp = document.createElement('optgroup');
+          grp.label = 'My Channels (this browser)';
+          for (const o of groups.local) addOption(o, grp);
+          channelSel.appendChild(grp);
         }
         // If current filter isn't in the list (encrypted hash, stale, or
         // race with cache), keep it as a selected option so the UI reflects state.

--- a/test-all.sh
+++ b/test-all.sh
@@ -11,6 +11,7 @@ echo ""
 echo "── Unit Tests ──"
 node test-packet-filter.js
 node test-packet-filter-ux.js
+node test-packets-local-channels.js
 node test-aging.js
 node test-issue-1065-gesture-hints-gates.js
 node test-frontend-helpers.js

--- a/test-packets-local-channels.js
+++ b/test-packets-local-channels.js
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for the packets channel-picker option merge.
+ *
+ * Locally-added channels (keys stored in the browser only) are invisible to
+ * the server, so /api/channels never lists them. packets.js derives their
+ * server-side "enc_<HH>" channel hash client-side and offers them as an
+ * extra option group. buildChannelOptions() does that merge; it is pure and
+ * exported as window._packetsBuildChannelOptionsForTest.
+ *
+ * Covers: sorting, server-list passthrough, local append, dedupe by hash
+ * value, dedupe by name (server holds the key too), and junk input.
+ */
+'use strict';
+const vm = require('vm');
+const fs = require('fs');
+const assert = require('assert');
+
+// packets.js expects a browser at call time; the merge helper touches none
+// of it. Load in a tolerant sandbox and grab the exported helper — it is
+// assigned before any DOM-dependent code runs.
+const noop = () => {};
+const fakeEl = {
+  addEventListener: noop, removeEventListener: noop, appendChild: noop, remove: noop,
+  querySelector: () => null, querySelectorAll: () => [], setAttribute: noop,
+  getAttribute: () => null, classList: { add: noop, remove: noop, toggle: noop, contains: () => false },
+  style: {}, dataset: {}, textContent: '', innerHTML: '',
+};
+const doc = {
+  readyState: 'complete', createElement: () => ({ ...fakeEl }), head: fakeEl, body: fakeEl,
+  getElementById: () => null, querySelector: () => null, querySelectorAll: () => [],
+  addEventListener: noop, removeEventListener: noop,
+};
+const win = {
+  addEventListener: noop, removeEventListener: noop,
+  matchMedia: () => ({ matches: false, addEventListener: noop, removeEventListener: noop }),
+  // packets.js fails loud if this module is missing (#1799).
+  PayloadLabels: { SHORT_BY_ID: {} },
+};
+const ctx = {
+  window: win, document: doc, console, Date, Math, JSON, Set, Map, Array, Object, Promise, Error,
+  setTimeout, clearTimeout, setInterval, clearInterval,
+  history: { replaceState: noop, pushState: noop },
+  location: { hash: '', href: '', pathname: '/' },
+  navigator: { userAgent: 'node' },
+  localStorage: { getItem: () => null, setItem: noop, removeItem: noop },
+  registerPage: noop,
+  api: () => Promise.resolve({}),
+  fetch: () => Promise.resolve({ json: () => Promise.resolve({}) }),
+};
+ctx.self = ctx;
+vm.createContext(ctx);
+try {
+  vm.runInContext(fs.readFileSync('public/packets.js', 'utf8'), ctx);
+} catch (e) {
+  // Downstream init may throw on the stub DOM — fine, the helper is exported
+  // near the top of the module.
+}
+
+const build = win._packetsBuildChannelOptionsForTest;
+assert.strictEqual(typeof build, 'function', 'buildChannelOptions must be exported for tests');
+
+// buildChannelOptions returns objects created inside the vm realm, whose
+// prototypes differ from this realm's — deepStrictEqual would reject them on
+// identity alone. Compare structurally.
+const plain = (v) => JSON.parse(JSON.stringify(v));
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log('  ok - ' + name);
+}
+
+console.log('packets channel-picker option merge');
+
+test('empty inputs produce empty groups', () => {
+  const r = build([], []);
+  assert.deepStrictEqual(plain(r), { server: [], local: [] });
+  const r2 = build(null, undefined);
+  assert.deepStrictEqual(plain(r2), { server: [], local: [] });
+});
+
+test('server channels are sorted case-insensitively by label', () => {
+  const r = build([{ hash: 'zeta', name: 'zeta' }, { hash: 'Alpha', name: 'Alpha' }, { hash: 'mid', name: 'mid' }], []);
+  assert.deepStrictEqual(plain(r.server.map(o => o.value)), ['Alpha', 'mid', 'zeta']);
+  assert.strictEqual(r.local.length, 0);
+});
+
+test('server channel without a name falls back to its hash', () => {
+  const r = build([{ hash: 'enc_A5' }], []);
+  assert.deepStrictEqual(plain(r.server), [{ value: 'enc_A5', label: 'enc_A5' }]);
+});
+
+test('local channels are appended as their own group', () => {
+  const r = build(
+    [{ hash: 'public', name: 'public' }],
+    [{ value: 'enc_A5', name: '#mytown', label: '#mytown' }]
+  );
+  assert.deepStrictEqual(plain(r.server), [{ value: 'public', label: 'public' }]);
+  assert.deepStrictEqual(plain(r.local), [{ value: 'enc_A5', label: '#mytown' }]);
+});
+
+test('local channel is dropped when the server already lists that hash', () => {
+  const r = build(
+    [{ hash: 'enc_A5', name: 'enc_A5' }],
+    [{ value: 'enc_A5', name: '#mytown', label: '#mytown' }]
+  );
+  assert.strictEqual(r.local.length, 0);
+});
+
+test('local channel is dropped when the server decrypts it under the same name', () => {
+  const r = build(
+    [{ hash: '#MyTown', name: '#MyTown' }],
+    [{ value: 'enc_A5', name: '#mytown', label: '#mytown' }]
+  );
+  assert.strictEqual(r.local.length, 0, 'name match is case-insensitive');
+});
+
+test('duplicate local entries collapse to one option', () => {
+  const r = build([], [
+    { value: 'enc_A5', name: '#a', label: '#a' },
+    { value: 'enc_A5', name: '#b', label: '#b' },
+  ]);
+  assert.deepStrictEqual(plain(r.local), [{ value: 'enc_A5', label: '#a' }]);
+});
+
+test('local options are sorted and use their display label', () => {
+  const r = build([], [
+    { value: 'enc_02', name: 'psk:deadbeef', label: 'Work PSK' },
+    { value: 'enc_01', name: '#alpha', label: '#alpha' },
+  ]);
+  assert.deepStrictEqual(plain(r.local), [
+    { value: 'enc_01', label: '#alpha' },
+    { value: 'enc_02', label: 'Work PSK' },
+  ]);
+});
+
+test('valueless / junk entries are skipped', () => {
+  const r = build([{ name: '' }, null, {}], [null, { name: '#x' }, { value: '' }]);
+  assert.deepStrictEqual(plain(r), { server: [], local: [] });
+});
+
+// --- collectLocalChannels(): stored keys → "enc_<HH>" -------------------
+// Stubs ChannelDecrypt with the real crypto (node) so the derived value is
+// checked against a genuine SHA-256(key)[0], not a fixture.
+
+const crypto = require('crypto');
+const collect = win._packetsCollectLocalChannelsForTest;
+assert.strictEqual(typeof collect, 'function', 'collectLocalChannels must be exported for tests');
+
+function fakeChannelDecrypt(keys, labels) {
+  return {
+    getStoredKeys: () => keys,
+    getLabel: (name) => (labels && labels[name]) || '',
+    hexToBytes: (hex) => Uint8Array.from(Buffer.from(hex, 'hex')),
+    computeChannelHash: async (keyBytes) => crypto.createHash('sha256').update(keyBytes).digest()[0],
+  };
+}
+
+function deriveKeyHex(channelName) {
+  return crypto.createHash('sha256').update(channelName).digest().subarray(0, 16).toString('hex');
+}
+
+function expectedEncValue(channelName) {
+  const key = crypto.createHash('sha256').update(channelName).digest().subarray(0, 16);
+  const hashByte = crypto.createHash('sha256').update(key).digest()[0];
+  return 'enc_' + hashByte.toString(16).padStart(2, '0').toUpperCase();
+}
+
+async function asyncTest(name, fn) {
+  await fn();
+  passed++;
+  console.log('  ok - ' + name);
+}
+
+(async () => {
+  console.log('\ncollectLocalChannels');
+
+  await asyncTest('no ChannelDecrypt module → no local channels', async () => {
+    win.ChannelDecrypt = undefined;
+    assert.deepStrictEqual(plain(await collect()), []);
+  });
+
+  await asyncTest('derives the server-side enc_<HH> value from the stored key', async () => {
+    // '#alpha' and '#zulu' hash to different bytes; both must round-trip.
+    const keys = { '#alpha': deriveKeyHex('#alpha'), '#zulu': deriveKeyHex('#zulu') };
+    win.ChannelDecrypt = fakeChannelDecrypt(keys);
+    const out = plain(await collect());
+    assert.strictEqual(out.length, 2);
+    assert.deepStrictEqual(out[0], { value: expectedEncValue('#alpha'), name: '#alpha', label: '#alpha' });
+    assert.deepStrictEqual(out[1], { value: expectedEncValue('#zulu'), name: '#zulu', label: '#zulu' });
+    // Uppercase, zero-padded — matches cmd/ingestor/decoder.go's "%02X".
+    for (const o of out) assert.ok(/^enc_[0-9A-F]{2}$/.test(o.value), 'bad value ' + o.value);
+  });
+
+  await asyncTest('uses the stored display label when present', async () => {
+    win.ChannelDecrypt = fakeChannelDecrypt(
+      { 'psk:deadbeef': deriveKeyHex('#work') },
+      { 'psk:deadbeef': 'Work PSK' }
+    );
+    const out = plain(await collect());
+    assert.deepStrictEqual(out, [{ value: expectedEncValue('#work'), name: 'psk:deadbeef', label: 'Work PSK' }]);
+  });
+
+  await asyncTest('skips malformed keys instead of throwing', async () => {
+    win.ChannelDecrypt = fakeChannelDecrypt({
+      '#short': 'aabb',                    // not 16 bytes
+      '#empty': '',
+      '#null': null,
+      '#good': deriveKeyHex('#good'),
+    });
+    const out = plain(await collect());
+    assert.deepStrictEqual(out, [{ value: expectedEncValue('#good'), name: '#good', label: '#good' }]);
+  });
+
+  await asyncTest('a throwing getStoredKeys degrades to no local channels', async () => {
+    win.ChannelDecrypt = { getStoredKeys: () => { throw new Error('quota'); } };
+    assert.deepStrictEqual(plain(await collect()), []);
+  });
+
+  console.log(`\n${passed} tests passed`);
+})().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Problem

Channels an operator adds in their own browser (Channels page → Add channel) never
appear in the Packets page channel dropdown.

Those keys live only in `localStorage` and never reach the server
(`channel-decrypt.js` keeps them client-side by design). The ingestor therefore
can't decrypt that traffic and files it under the synthetic channel hash
`enc_<HH>`, and `/api/channels` excludes `enc_` rows. The picker is populated
purely from that endpoint, so a channel you just added is invisible there even
though its packets are in the DB.

## Fix (frontend only)

Derive the same `enc_<HH>` value client-side from each stored key
(`SHA-256(key)[0]`, the derivation the decoder uses) and offer those channels
as an extra **"My Channels (this browser)"** option group.

No backend change: `/api/packets?channel=enc_<HH>` already matches on that value
in both the SQLite path and the in-memory store (`packetMatchesChannel`).

- A local channel is dropped when the server already exposes it, either by the
  same `enc_` hash or by the same channel name, so nothing is listed twice.
- Options are built with `textContent`, never `innerHTML` (channel names are
  untrusted input, #812).

## Perf

One SHA-256 per stored key (a handful), once per page init, issued in parallel
with the existing `/api/channels` fetch. No new request, no work in a render
path.

## Tests

`test-packets-local-channels.js`: 14 unit tests covering merge/dedupe/sort and
the `enc_<HH>` derivation, checked against real node-crypto SHA-256 including
the zero-padded uppercase format. Wired into `test-all.sh` and the CI unit-test
step.
