### PR TITLE
fix(ingestor): backfill transmissions.last_seen in bounded batches

### DIFF
--- a/cmd/ingestor/backfill_tx_last_seen.go
+++ b/cmd/ingestor/backfill_tx_last_seen.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"strings"
+)
+
+// backfillTxLastSeenBatch bounds how many transmissions one backfill
+// transaction touches before it commits and releases the writer lock.
+//
+// Releasing between batches is the entire point. writerMu serialises every
+// wrapped writer call, so while this migration holds it the MQTT ingest path
+// is blocked; the unbounded statement this replaces held it for the whole
+// table. Go's sync.Mutex hands off to a waiter that has been blocked for 1ms,
+// so an ingest goroutine queued behind a batch is served at the next batch
+// boundary rather than after the entire backfill.
+//
+// 500 rows because the work per row is one indexed MAX() over that
+// transmission's observations, far cheaper than the prune's per-row delete
+// cascade — and the commit count stays low: a 71k-transmission database is
+// 143 transactions, not 71k.
+const backfillTxLastSeenBatch = 500
+
+// backfillTxLastSeenBatchIDs selects the next window of transmissions to
+// consider. The cursor is doing two jobs and both are load-bearing:
+//
+//   - It bounds the scan. Each batch resumes at the id the previous one
+//     stopped at, so the migration walks the table once in total rather than
+//     re-scanning from the start for every batch.
+//   - It guarantees termination. A transmission with no observations keeps
+//     last_seen = 0 — MAX() over no rows is NULL and COALESCE falls back to
+//     the existing value — so a loop keyed on `last_seen = 0` alone would hand
+//     itself the same rows forever. Advancing past every row the window
+//     returned, filled or not, visits each row exactly once.
+//
+// ORDER BY id with id > ? is satisfiable from the rowid, which
+// TestBackfillTxLastSeenBatchUsesRowidRange pins.
+const backfillTxLastSeenBatchIDs = `SELECT id FROM transmissions WHERE last_seen = 0 AND id > ? ORDER BY id LIMIT ?`
+
+// backfillTxLastSeen fills transmissions.last_seen from the newest observation
+// of each transmission, in bounded transactions.
+//
+// Returns the number of transmissions that actually received a value, which is
+// not the number of rows considered: rows with no observations are passed over
+// and stay at 0, to be filled by the per-observation UPDATE if one ever
+// arrives.
+//
+// On error the rows already committed keep their values and the count so far
+// is returned alongside it — those writes are done, and reporting 0 would be
+// wrong. The next boot re-runs the migration, which resumes from the first
+// row still at 0.
+func (s *Store) backfillTxLastSeen(ctx context.Context) (int64, error) {
+	var total int64
+	var cursor int64
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+
+		var ids []int64
+		var updated int64
+		// Tagged for writer-perf visibility (#1340), the same way the prune is.
+		err := s.WriterTx("tx_last_seen_backfill", func(tx *sql.Tx) error {
+			rows, err := tx.QueryContext(ctx, backfillTxLastSeenBatchIDs, cursor, backfillTxLastSeenBatch)
+			if err != nil {
+				return fmt.Errorf("select batch: %w", err)
+			}
+			for rows.Next() {
+				var id int64
+				if err := rows.Scan(&id); err != nil {
+					rows.Close()
+					return fmt.Errorf("scan batch id: %w", err)
+				}
+				ids = append(ids, id)
+			}
+			if err := rows.Err(); err != nil {
+				rows.Close()
+				return fmt.Errorf("batch rows: %w", err)
+			}
+			rows.Close()
+			if len(ids) == 0 {
+				return nil
+			}
+
+			// The EXISTS guard keeps the statement from writing a row back to
+			// itself: a transmission with no observations has nothing to derive,
+			// and without it COALESCE writes that row's existing 0 over its
+			// existing 0 — pointless WAL churn, and RowsAffected would then report
+			// rows considered rather than rows filled, which is what gets logged.
+			res, err := tx.ExecContext(ctx, `
+				UPDATE transmissions
+				SET last_seen = COALESCE((
+					SELECT MAX(timestamp) FROM observations WHERE transmission_id = transmissions.id
+				), last_seen)
+				WHERE id IN (`+placeholders(len(ids))+`)
+				  AND EXISTS (SELECT 1 FROM observations WHERE transmission_id = transmissions.id)`, toArgs(ids)...)
+			if err != nil {
+				return fmt.Errorf("backfill batch: %w", err)
+			}
+			updated, _ = res.RowsAffected()
+			return nil
+		})
+		if err != nil {
+			return total, err
+		}
+		if len(ids) == 0 {
+			break
+		}
+
+		// Past every row the window returned, not just the filled ones.
+		cursor = ids[len(ids)-1]
+		total += updated
+		if len(ids) < backfillTxLastSeenBatch {
+			break
+		}
+	}
+
+	return total, nil
+}
+
+// placeholders returns "?, ?, ?" for n arguments. The batch is bounded by
+// backfillTxLastSeenBatch, so this stays far below SQLITE_MAX_VARIABLE_NUMBER.
+func placeholders(n int) string {
+	return strings.TrimSuffix(strings.Repeat("?,", n), ",")
+}
+
+func toArgs(ids []int64) []interface{} {
+	args := make([]interface{}, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	return args
+}
+
+// logBackfillTxLastSeen runs the backfill and reports what it did, so the
+// async-migration call site stays a one-liner.
+func (s *Store) logBackfillTxLastSeen(ctx context.Context) error {
+	log.Println("[migration/async] Backfilling transmissions.last_seen from MAX(observations.timestamp)...")
+	n, err := s.backfillTxLastSeen(ctx)
+	if err != nil {
+		log.Printf("[migration/async] transmissions.last_seen backfill failed after %d rows: %v", n, err)
+		return err
+	}
+	log.Printf("[migration/async] transmissions.last_seen backfill complete: %d rows updated", n)
+	return nil
+}

--- a/cmd/ingestor/backfill_tx_last_seen_test.go
+++ b/cmd/ingestor/backfill_tx_last_seen_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// openBackfillStore is the prune tests' fixture shape: a real store on a
+// throwaway file, so the backfill runs against the schema it runs against in
+// production rather than a hand-rolled subset.
+func openBackfillStore(t *testing.T, name string) *Store {
+	t.Helper()
+	store, err := OpenStore(filepath.Join(t.TempDir(), name))
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	// OpenStore schedules tx_last_seen_backfill_v1 itself, in a goroutine. Seed
+	// before it finishes and the migration races the test for the same rows —
+	// which is how this fixture first reported 1036 of 1037 rows backfilled.
+	store.WaitForAsyncMigrations()
+	return store
+}
+
+// seedTxWithObservations inserts n transmissions with last_seen = 0, each
+// carrying obsPerTx observations whose timestamps are the row's own index plus
+// an offset, so every transmission has a distinct, checkable MAX(timestamp).
+// Returns the expected last_seen per transmission id.
+func seedTxWithObservations(t *testing.T, store *Store, n, obsPerTx int) map[int64]int64 {
+	t.Helper()
+	want := map[int64]int64{}
+	// transmissions.hash is UNIQUE, and a test may seed twice.
+	seedRun := nextBackfillSeedRun()
+	base := time.Now().UTC().Add(-24 * time.Hour).Unix()
+	for i := 0; i < n; i++ {
+		res, err := store.db.Exec(
+			`INSERT INTO transmissions (raw_hex, hash, first_seen, route_type, payload_type, payload_version, decoded_json, last_seen)
+			 VALUES ('AA', ?, ?, 0, 1, 1, '{}', 0)`,
+			fmt.Sprintf("backfill-%d-%d", seedRun, i), time.Now().UTC().Format(time.RFC3339),
+		)
+		if err != nil {
+			t.Fatalf("seed tx %d: %v", i, err)
+		}
+		txID, err := res.LastInsertId()
+		if err != nil {
+			t.Fatalf("seed tx %d id: %v", i, err)
+		}
+		var max int64
+		for j := 0; j < obsPerTx; j++ {
+			ts := base + int64(i*10+j)
+			if ts > max {
+				max = ts
+			}
+			if _, err := store.db.Exec(
+				`INSERT INTO observations (transmission_id, observer_idx, direction, snr, rssi, score, path_json, timestamp)
+				 VALUES (?, ?, 'rx', 1.0, -100, 0, '[]', ?)`,
+				txID, j, ts,
+			); err != nil {
+				t.Fatalf("seed obs %d/%d: %v", i, j, err)
+			}
+		}
+		if obsPerTx > 0 {
+			want[txID] = max
+		}
+	}
+	return want
+}
+
+func txLastSeen(t *testing.T, store *Store, id int64) int64 {
+	t.Helper()
+	var v int64
+	if err := store.db.QueryRow(`SELECT last_seen FROM transmissions WHERE id = ?`, id).Scan(&v); err != nil {
+		t.Fatalf("read last_seen for %d: %v", id, err)
+	}
+	return v
+}
+
+// TestBackfillTxLastSeenRunsInBoundedBatches is the perf assertion. The
+// migration this replaces issued ONE unbounded UPDATE with a correlated
+// subquery per row, which on an operator database (71k tx / 1.5M obs) wedged
+// every reader behind the writer lock for 10-15 minutes (#1724). Counting
+// writer transactions is the deterministic proxy: N transactions means the
+// lock was released N-1 times, so the worst-case stall is one batch.
+func TestBackfillTxLastSeenRunsInBoundedBatches(t *testing.T) {
+	store := openBackfillStore(t, "backfill-batched.db")
+	const n = backfillTxLastSeenBatch*2 + 37
+	want := seedTxWithObservations(t, store, n, 2)
+
+	ResetWriterStatsForTest()
+
+	updated, err := store.backfillTxLastSeen(context.Background())
+	if err != nil {
+		t.Fatalf("backfillTxLastSeen: %v", err)
+	}
+	if updated != int64(n) {
+		t.Fatalf("updated %d transmissions, want %d", updated, n)
+	}
+
+	// 2 full batches + 1 partial, which ends the loop.
+	if got := store.WriterStatsSnapshot()["tx_last_seen_backfill"].Count; got != 3 {
+		t.Fatalf("expected 3 writer transactions for %d rows at batch size %d, got %d "+
+			"(1 means the backfill is not chunked and holds the writer lock for the whole table)",
+			n, backfillTxLastSeenBatch, got)
+	}
+
+	for id, ts := range want {
+		if got := txLastSeen(t, store, id); got != ts {
+			t.Fatalf("transmission %d: last_seen = %d, want %d", id, got, ts)
+		}
+	}
+}
+
+// TestBackfillTxLastSeenTerminatesOnRowsItCannotFill is the correctness risk
+// the batching introduces. A transmission with no observations keeps
+// last_seen = 0, so a loop that re-selects on `last_seen = 0` alone would hand
+// itself the same rows forever. The cursor is what makes each row be visited
+// once; without it this test hangs rather than fails, which is why the batch
+// count is asserted too.
+func TestBackfillTxLastSeenTerminatesOnRowsItCannotFill(t *testing.T) {
+	store := openBackfillStore(t, "backfill-unfillable.db")
+	seedTxWithObservations(t, store, 5, 0) // no observations: nothing to backfill
+	want := seedTxWithObservations(t, store, 3, 1)
+
+	ResetWriterStatsForTest()
+
+	done := make(chan struct{})
+	var updated int64
+	var err error
+	go func() {
+		updated, err = store.backfillTxLastSeen(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("backfillTxLastSeen did not terminate: rows it cannot fill are being re-selected")
+	}
+	if err != nil {
+		t.Fatalf("backfillTxLastSeen: %v", err)
+	}
+	if updated != 3 {
+		t.Fatalf("updated %d, want 3 (the five observation-less rows must not count)", updated)
+	}
+	if got := store.WriterStatsSnapshot()["tx_last_seen_backfill"].Count; got != 1 {
+		t.Fatalf("expected the 8 rows to fit one batch, got %d transactions", got)
+	}
+	for id, ts := range want {
+		if got := txLastSeen(t, store, id); got != ts {
+			t.Fatalf("transmission %d: last_seen = %d, want %d", id, got, ts)
+		}
+	}
+}
+
+// TestBackfillTxLastSeenLeavesFilledRowsAlone pins the WHERE clause: a row
+// that already carries a value is the steady-state maintained by the
+// per-observation UPDATE, and re-deriving it would undo a value newer than the
+// observations this database still holds after a retention prune.
+func TestBackfillTxLastSeenLeavesFilledRowsAlone(t *testing.T) {
+	store := openBackfillStore(t, "backfill-filled.db")
+	want := seedTxWithObservations(t, store, 3, 1)
+
+	var pinned int64
+	for id := range want {
+		pinned = id
+		break
+	}
+	const sentinel = int64(4102444800) // 2100-01-01, far from any seeded timestamp
+	if _, err := store.db.Exec(`UPDATE transmissions SET last_seen = ? WHERE id = ?`, sentinel, pinned); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.backfillTxLastSeen(context.Background()); err != nil {
+		t.Fatalf("backfillTxLastSeen: %v", err)
+	}
+
+	if got := txLastSeen(t, store, pinned); got != sentinel {
+		t.Fatalf("already-filled transmission %d: last_seen = %d, want it untouched at %d", pinned, got, sentinel)
+	}
+}
+
+// TestBackfillTxLastSeenBatchUsesRowidRange pins the query plan of the batch
+// selector. The cursor exists so each batch resumes where the last one
+// stopped; if a future edit costs it the rowid range, every batch rescans the
+// table from the start and the chunking makes the migration slower than the
+// single statement it replaced. Transaction counts cannot see that.
+func TestBackfillTxLastSeenBatchUsesRowidRange(t *testing.T) {
+	store := openBackfillStore(t, "backfill-plan.db")
+	seedTxWithObservations(t, store, 20, 1)
+
+	rows, err := store.db.Query("EXPLAIN QUERY PLAN "+backfillTxLastSeenBatchIDs, 0, backfillTxLastSeenBatch)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN: %v", err)
+	}
+	defer rows.Close()
+	var plan string
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notused, &detail); err != nil {
+			t.Fatalf("scan plan row: %v", err)
+		}
+		plan += detail + "\n"
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("plan rows: %v", err)
+	}
+	// The shape that matters is a SEARCH bounded by the cursor, whichever index
+	// SQLite picks — today the partial idx_tx_last_seen_zero, which covers it
+	// outright. A SCAN here means every batch re-reads the table from the start.
+	if !containsAll(plan, "SEARCH", "transmissions", "(id>?)") {
+		t.Fatalf("batch selector does not resume from the cursor; plan was:\n%s", plan)
+	}
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		found := false
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// nextBackfillSeedRun hands each seeding call its own hash namespace.
+var backfillSeedRuns int
+
+func nextBackfillSeedRun() int {
+	backfillSeedRuns++
+	return backfillSeedRuns
+}

--- a/cmd/ingestor/db.go
+++ b/cmd/ingestor/db.go
@@ -194,21 +194,10 @@ func OpenStoreWithInterval(dbPath string, sampleIntervalSec int) (*Store, error)
 	// inserts maintain the column inline (see InsertTransmission below).
 	// PREFLIGHT: async=true reason="full-table backfill JOIN (1.9M+ obs × 86k+ tx in prod) — must not block ingestor boot"
 	if err := s.RunAsyncMigration(context.Background(), "tx_last_seen_backfill_v1",
-		func(ctx context.Context, d *sql.DB) error {
-			log.Println("[migration/async] Backfilling transmissions.last_seen from MAX(observations.timestamp)...")
-			res, err := d.ExecContext(ctx, `
-				UPDATE transmissions
-				SET last_seen = COALESCE((
-					SELECT MAX(timestamp) FROM observations WHERE transmission_id = transmissions.id
-				), last_seen)
-				WHERE last_seen = 0
-			`)
-			if err != nil {
-				return err
-			}
-			n, _ := res.RowsAffected()
-			log.Printf("[migration/async] transmissions.last_seen backfill complete: %d rows updated", n)
-			return nil
+		func(ctx context.Context, _ *sql.DB) error {
+			// Chunked: see backfill_tx_last_seen.go. The single unbounded UPDATE
+			// this replaces held the writer lock for the whole table (#1724).
+			return s.logBackfillTxLastSeen(ctx)
 		}); err != nil {
 		log.Printf("[migration/async] scheduling tx_last_seen_backfill_v1 failed: %v", err)
 	}


### PR DESCRIPTION
Extracted from #1735, which has been open since June and cannot be rebased cheaply: three months behind across 17 files, and it carries the async-migration progress UI as well. This is the half with a measured problem behind it.

## The problem, still on master

`tx_last_seen_backfill_v1` runs as one unbounded `UPDATE` with a correlated subquery per row (`cmd/ingestor/db.go:196`):

```sql
UPDATE transmissions
SET last_seen = COALESCE((SELECT MAX(timestamp) FROM observations
                          WHERE transmission_id = transmissions.id), last_seen)
WHERE last_seen = 0
```

No `LIMIT`, no batching anywhere in `async_migration.go`. On the operator database in #1724 (71k transmissions, 1.5M observations, ~2GB) that wedged every reader behind the writer for 10-15 minutes *after* cold load reported complete. `/api/stats`, which is served from memory, hit 213s.

It is the same shape #2000 just fixed for the retention prune, so this uses the same pattern and the same kind of test.

## Who this reaches

The code is still on master, but the migration runs once per database. An instance whose `_async_migrations` row for `tx_last_seen_backfill_v1` is already `done` never runs the new code. On the instance I run, that row reads `done` since 2026-06-14, and 0 transmissions have `last_seen = 0`.

So this helps instances upgrading from a version before the migration existed, and instances where it is recorded as `failed` or `pending_async`. It changes nothing for instances that already completed it.

## The change

500 transmissions per `WriterTx`, committing between batches so an ingest goroutine queued behind the migration is served at the next boundary rather than after the whole table.

Two things the batching needs that the single statement did not:

**A cursor, or the loop never terminates.** A transmission with no observations keeps `last_seen = 0` (`MAX()` over no rows is NULL and `COALESCE` falls back to the existing value), so a loop re-selecting on `last_seen = 0` alone hands itself the same rows forever. Each batch resumes past the last id the previous window returned, filled or not. The same cursor bounds the scan, so the migration walks the table once in total instead of re-reading it per batch.

**An `EXISTS` guard**, so a row with nothing to derive is not written back to itself: no pointless WAL churn, and the logged count means rows filled rather than rows considered.

## Tests

- `RunsInBoundedBatches`: 1037 rows is 3 writer transactions, not 1, counted off the same writer stats the prune test uses. A 1 there means the lock is held for the whole table.
- `TerminatesOnRowsItCannotFill`: a full batch (500) of observation-less rows plus 3 fillable ones. The unfillable rows neither loop nor count as filled, and the run takes 2 writer transactions. The first version seeded 5 unfillable rows, fewer than a batch, so the short-batch break ended the loop before the cursor was used: with the cursor update replaced by a no-op, all four tests still passed. With a full batch, the same mutation fails after the 20s context deadline with `did not terminate`.
- `LeavesFilledRowsAlone`: a row already carrying a value keeps it, so a value newer than the observations still present after a retention prune is not re-derived downward.
- `BatchUsesRowidRange`: pins the plan to a `SEARCH` bounded by `(id>?)`. Transaction counts cannot see a batch that rescans from the start; today SQLite covers it with the partial `idx_tx_last_seen_zero`.

One fixture note worth repeating, because it bit me: `OpenStore` schedules this very migration in a goroutine, so a test that seeds immediately races it. The fixture now waits for async migrations first. Before that, the batching test reported 1036 of 1037 rows backfilled, which looked like an off-by-one in the cursor and was not.

## Verified

`go test ./cmd/ingestor` passes apart from `TestWriteStatsAtomic_SymlinkAtDestIsReplaced`, which fails identically on a branch without this change: creating a symlink needs a privilege my Windows account does not hold. `gofmt` and `go vet` clean.

Mutations run against the tests: cursor update removed (fails `TerminatesOnRowsItCannotFill`), `EXISTS` guard removed (fails, `updated 503, want 3`), `last_seen = 0` dropped from the selector (fails `LeavesFilledRowsAlone` and `BatchUsesRowidRange`).

Not done: no measurement of the new hold time on a production-sized database. The prune's equivalent change was accepted on the transaction-count proxy plus the query plan, and this is the same argument. If you want the real number I can produce it on a staging instance the way I did for #1992. `-race` was not run locally (no cgo toolchain here); the CI race job covers it.
